### PR TITLE
Some style change on lispifiers

### DIFF
--- a/py4cl.py
+++ b/py4cl.py
@@ -327,7 +327,7 @@ if numpy_is_installed: #########################################################
 	# check for subtypes to avoid casing on u/int64/32/16/8.
 	lispifiers.update({
 		numpy.ndarray: ndarray_lispifier,
-		numpy.float64: lambda x : float_lispifier,
+		numpy.float64: float_lispifier,
 		numpy.float32: lambda x : infnan_lispifier(str(x)),
 		numpy.bool_  : lambda x : "1" if x else "0"})
 # end of "if numpy_is_installed" ###############################################

--- a/py4cl.py
+++ b/py4cl.py
@@ -16,7 +16,7 @@ import inspect
 import json
 import os
 import signal
-import traceback as tb
+import traceback
 
 numpy_is_installed = False
 try:
@@ -220,6 +220,12 @@ def float_lispifier (float):
         lispified_float = str(float)+"d0"
     return infnan_lispifier(lispified_float)
 
+def Exception_lispifier (obj):
+	if config["printPythonTraceback"]:
+		return "".join(traceback.format_exception(type(obj), obj, obj.__traceback__))
+	else:
+		return str(obj)
+
 lispifiers = {
     bool              : lambda x: "T" if x else "NIL",
     type(None)        : lambda x: "NIL",
@@ -341,8 +347,7 @@ def lispify(obj):
 
 	try:
 		if isinstance(obj, Exception):
-			return ("".join(tb.format_exception(type(obj), obj, obj.__traceback__))
-					if config["printPythonTraceback"] else str(obj))
+			return Exception_lispifier(obj)
 		elif numpy_is_installed and isinstance(obj, numpy.integer):
 			return str(obj)
 		else:
@@ -386,8 +391,7 @@ def send_value(value):
 	except Exception as e:
 		# At this point the message type has been sent,
 		# so we cannot change to throw an exception/signal condition
-		value_str = ("Lispify error: " + "".join(tb.format_exception(type(e), e, e.__traceback__)) \
-					 if config["printPythonTraceback"] else str(e))
+		value_str = "Lispify error: {0}".format(Exception_lispifier(e))
 	excess_char_count = (0 if os.name != "nt" else value_str.count("\n"))
 	print(len(value_str)+excess_char_count, file = return_stream, flush=True)
 	return_stream.write(value_str)

--- a/py4cl.py
+++ b/py4cl.py
@@ -495,13 +495,23 @@ if numpy_is_installed:
 # Lisp-side customize-able lispifiers
 # FIXME: Is there a better way than going to each of the above and doing manually?
 old_lispifiers = lispifiers.copy()
-for key in lispifiers.keys():
-	lispifiers[key] = eval(
-		"""
-lambda x: "#.(py4cl2::customize " + old_lispifiers[{0}](x) + ")"
-""".format(("" if key.__module__ == "builtins" or key.__module__ == "__main__" \
-			else key.__module__ + ".") + key.__name__ if key.__name__ != "NoneType" \
-		   else "type(None)"))
+def customize_lispifiers ():
+    def fun_1 (key):
+        if key.__module__ == "builtins" or key.__module__ == "__main__":
+            return ""
+	else:
+            return key.__module__ + "."
+    def fun_2 (key):
+        if key.__name__ != "NoneType":
+            return key.__name__
+        else:
+            return "type(None)"
+    for key in lispifiers.keys():
+        expr = """lambda x: "#.(py4cl2::customize " + old_lispifiers[{0}](x) + ")"  """
+	expr = expr.format(fun_1(key) + fun_2(key))
+        lispifiers[key] = eval(expr)
+
+customize_lispifiers()
 
 async_results = {}  # Store for function results. Might be Exception
 async_handle = itertools.count(0) # Running counter

--- a/py4cl.py
+++ b/py4cl.py
@@ -205,7 +205,10 @@ def dict_lispifier (dict):
     return segment_0 + segment_1 + segment_2
 
 def tuple_lispifier (tuple):
-    return "(quote (" + " ".join(lispify(elt) for elt in tuple) + "))"
+    if len(tuple) == 0:
+        return "\"()\""
+    else:
+        return "(quote (" + " ".join(lispify(elt) for elt in tuple) + "))"
 
 def infnan_lispifier (lispified_float):
     infnan = {"infd0" : "float-features:double-float-positive-infinity",

--- a/py4cl.py
+++ b/py4cl.py
@@ -499,7 +499,7 @@ def customize_lispifiers ():
     def fun_1 (key):
         if key.__module__ == "builtins" or key.__module__ == "__main__":
             return ""
-    else:
+        else:
             return key.__module__ + "."
     def fun_2 (key):
         if key.__name__ != "NoneType":

--- a/py4cl.py
+++ b/py4cl.py
@@ -214,8 +214,8 @@ def infnan_lispifier (lispified_float):
               "-inf"  : "float-features:single-float-negative-infinity",
               "nan"   : "float-features:single-float-nan",
               "nand0" : "float-features:double-float-nan"}
-    if lispified_float in table:
-        return table[lispified_float]
+    if lispified_float in infnan:
+        return infnan[lispified_float]
     else:
         return lispified_float
 

--- a/py4cl.py
+++ b/py4cl.py
@@ -208,7 +208,7 @@ def float_lispifier (float):
               "-inf"  : "float-features:single-float-negative-infinity",
               "nan"   : "float-features:single-float-nan",
               "nand0" : "float-features:double-float-nan"}
-    if str(float).find("e") != -1:
+    if "e" in str(float):
         lispified_float = str(float).replace("e", "d")
     else:
         lispified_float = str(float)+"d0"
@@ -301,7 +301,7 @@ if numpy_is_installed: #########################################################
 	# Register the handler to convert Python -> Lisp strings
 	lispifiers.update({
 		numpy.ndarray: lispify_ndarray,
-		numpy.float64: lambda x : lispify_infnan_if_needed(str(x).replace("e", "d") if str(x).find("e") != -1 else str(x)+"d0"),
+		numpy.float64: lambda x : lispify_infnan_if_needed(str(x).replace("e", "d") if "e" in str(x) else str(x)+"d0"),
 		numpy.float32: lambda x : lispify_infnan_if_needed(str(x)),
 		numpy.bool_  : lambda x : "1" if x else "0"
 		# The case for integers is handled inside lispify function. At best, you would want a way to compare / check for subtypes to avoid casing on u/int64/32/16/8.

--- a/py4cl.py
+++ b/py4cl.py
@@ -52,6 +52,12 @@ def load_config():
 
 load_config()
 
+# Handle fractions (python Fraction -> Lisp RATIO)
+# Lisp will pass strings containing "_py4cl_fraction(n,d)"
+# where n and d are integers.
+import fractions
+eval_globals["_py4cl_fraction"] = fractions.Fraction
+
 class Symbol(object):
 	"""
 	A wrapper around a string, representing a Lisp symbol.
@@ -230,8 +236,8 @@ lispifiers = {
     bool              : lambda x: "T" if x else "NIL",
     type(None)        : lambda x: "NIL",
     int               : str,
-    # floats in python are double-floats of common-lisp
-    float             : float_lispifier,
+    fractions.Fraction: str,
+    float             : float_lispifier, # floats in python are double-floats of common-lisp
     complex           : lambda x: "#C(" + lispify(x.real) + " " + lispify(x.imag) + ")",
     list              : lambda x: "#(" + " ".join(lispify(elt) for elt in x) + ")",
     tuple             : tuple_lispifier,
@@ -485,16 +491,6 @@ if numpy_is_installed:
 	eval_globals["_py4cl_numpy"] = numpy
 	eval_globals["_py4cl_load_pickled_ndarray"] \
 		= load_pickled_ndarray
-
-# Handle fractions (RATIO type)
-# Lisp will pass strings containing "_py4cl_fraction(n,d)"
-# where n and d are integers.
-
-import fractions
-eval_globals["_py4cl_fraction"] = fractions.Fraction
-
-# Turn a Fraction into a Lisp RATIO
-lispifiers[fractions.Fraction] = str
 
 # Lisp-side customize-able lispifiers
 # FIXME: Is there a better way than going to each of the above and doing manually?

--- a/py4cl.py
+++ b/py4cl.py
@@ -314,13 +314,17 @@ if numpy_is_installed: #########################################################
 		numpy.bool_  : lambda x : "1" if x else "0"})
 # end of "if numpy_is_installed" ###############################################
 
-def lispify_handle(obj):
+def handle_lispifier (obj):
 	"""
 	Store an object in a dictionary, and return a handle
 	"""
 	handle = next(python_handle)
 	python_objects[handle] = obj
-	return "#.(py4cl2::customize (py4cl2::make-python-object-finalize :type \""+str(type(obj))+"\" :handle "+str(handle)+"))"
+	return "#.(py4cl2::customize "                        + \
+		"(py4cl2::make-python-object-finalize :type " + \
+		"\"{0}\"".format(str(type(obj)))            + \
+		" :handle {0}".format(str(handle))          + \
+		"))"
 
 def lispify(obj):
 	"""
@@ -330,7 +334,7 @@ def lispify(obj):
 	"""
 	if return_values > 0:
 		if isinstance(obj, Exception): return str(obj)
-		else: return lispify_handle(obj)
+		else: return handle_lispifier(obj)
 
 	try:
 		if isinstance(obj, Exception):
@@ -342,7 +346,7 @@ def lispify(obj):
 			return lispifiers[type(obj)](obj)
 	except KeyError:
 		# Unknown type. Return a handle to a python object
-		return lispify_handle(obj)
+		return handle_lispifier(obj)
 
 def generator(function, stop_value):
 	temp = None

--- a/py4cl.py
+++ b/py4cl.py
@@ -237,7 +237,7 @@ def Exception_lispifier (obj):
 
 lispifiers = {
     bool              : lambda x: "T" if x else "NIL",
-    type(None)        : lambda x: "\"None\"",
+    type(None)        : lambda x: "\"None\"", # Better be "NIL"..?
     int               : str,
     fractions.Fraction: str,
     float             : float_lispifier, # floats in python are double-floats of common-lisp

--- a/py4cl.py
+++ b/py4cl.py
@@ -237,7 +237,7 @@ def Exception_lispifier (obj):
 
 lispifiers = {
     bool              : lambda x: "T" if x else "NIL",
-    type(None)        : lambda x: "NIL",
+    type(None)        : lambda x: "\"None\"",
     int               : str,
     fractions.Fraction: str,
     float             : float_lispifier, # floats in python are double-floats of common-lisp

--- a/py4cl.py
+++ b/py4cl.py
@@ -499,7 +499,7 @@ def customize_lispifiers ():
     def fun_1 (key):
         if key.__module__ == "builtins" or key.__module__ == "__main__":
             return ""
-	else:
+    else:
             return key.__module__ + "."
     def fun_2 (key):
         if key.__name__ != "NoneType":
@@ -508,7 +508,7 @@ def customize_lispifiers ():
             return "type(None)"
     for key in lispifiers.keys():
         expr = """lambda x: "#.(py4cl2::customize " + old_lispifiers[{0}](x) + ")"  """
-	expr = expr.format(fun_1(key) + fun_2(key))
+        expr = expr.format(fun_1(key) + fun_2(key))
         lispifiers[key] = eval(expr)
 
 customize_lispifiers()


### PR DESCRIPTION
1. Reorganized some lispifiers into proper functions

    Easier to read => Easier to modify in the future.

2. Also added `cl::` before some symbols, just to be safe.