### PR TITLE
Ajb/non blocking dispatch loop

### DIFF
--- a/PyQt6_example.py
+++ b/PyQt6_example.py
@@ -1,0 +1,23 @@
+def start_app (try_process_message):
+        import PyQt6
+        import sys
+        import matplotlib
+        import matplotlib.pyplot as plt
+        from PyQt6.QtWidgets import QApplication
+        from PyQt6.QtCore import QTimer
+        app = QApplication(sys.argv)
+
+        matplotlib.use("QtAgg")
+        # w = PyQt6.QMainWindow()
+        # w.show()
+        plot = plt.plot([1, 2, 3],[4, 5, 6])
+        plt.show(block=False)
+
+        timer = QTimer()
+        def process_messages():
+                try_process_message(blocking=False)
+        timer.timeout.connect(process_messages);
+        timer.start(100);
+        print("Going into main loop, will return when all windows closed")
+        app.exec()
+        print("No more windows, returning to default messsage_dispatch_loop")

--- a/README.md
+++ b/README.md
@@ -49,5 +49,18 @@ Please test using [py4cl2-tests](https://github.com/digikar99/py4cl2-tests).
 
 <img margin="auto" width="75%" src="./docs/readme_matplotlib.png"></img>
 
-Great thanks to [Ben Dudson](https://github.com/bendudson) for starting this project, and documenting it enough to make it more-buildable!
+# Running py4cl2 in a main GUI loop
 
+The example above with matplotlib was a static plot (no interactive zooming, no GUI).  To enable interactivity, the main thread of the Python process needs to be running a GUI main loop.  To do this, we can change the py4cl2 loop to not block and to be called regularly by the gui main loop.  To do so, see the example src/PyQt6_example.py where we create a matplotlib plot on the Qt6 backend.  To run it, you would do the following:
+```lisp
+  ;; so python can find the example module
+  (py4cl2:pyexec (format nil "import sys; sys.path.insert(0, '~a')"
+			 (directory-namestring
+			  (asdf:component-pathname
+			   (asdf:find-component :py4cl2 "python-code")))))
+  ;; start the gui loop and a simple plot.
+  (py4cl2::raw-py-exec/no-return "import PyQt6_example; PyQt6_example.start_app(try_process_message);")
+  (py4cl2:pyeval "1 + 1") ;; still works despite GUI refreshing as needed
+```
+
+Great thanks to [Ben Dudson](https://github.com/bendudson) for starting this project, and documenting it enough to make it more-buildable!

--- a/py4cl.py
+++ b/py4cl.py
@@ -436,21 +436,33 @@ def pythonize(value): # assumes the symbol name is downcased by the lisp process
 	"""
 	return str(value)[1:].replace("-", "_")
 
-def message_dispatch_loop():
+def message_dispatch_loop ():
+	while True:
+		try_process_message(blocking=True)
+
+def try_process_message(blocking=True):
 	"""
 	Wait for a message, dispatch on the type of message.
 	Message types are determined by the first character:
 
 	e  Evaluate an expression (expects string)
 	x  Execute a statement (expects string)
+	O  Enable handles
+	o  Disable handles
 	q  Quit
 	"""
 	global return_values  # Controls whether values or handles are returned
 	while True:
 		try:
 			output_stream.flush()
+			if not blocking:
+				os.set_blocking(sys.stdin.fileno(), False)
 			# Read command type
 			cmd_type = sys.stdin.read(1)
+			if cmd_type == "":
+				if not blocking:
+					os.set_blocking(sys.stdin.fileno(), True)
+				return None
 			# It is possible that python would have finished sending the data to CL
 			# but CL would still not have finished processing. We will receive further
 			# instructions only after CL has finished processing, and therefore we can delete
@@ -488,6 +500,8 @@ def message_dispatch_loop():
 python_objects = {}
 python_handle = itertools.count(0)
 
+# For user to use to give time to our dispatch loop
+eval_globals["try_process_message"] = try_process_message
 # Make callback function accessible to evaluation
 eval_globals["_py4cl_LispCallbackObject"] = LispCallbackObject
 eval_globals["_py4cl_Symbol"] = Symbol

--- a/src/callpython.lisp
+++ b/src/callpython.lisp
@@ -124,6 +124,18 @@ Passes strings as they are, without any 'pythonize'ation."
       ;; wait for python output
       (dispatch-messages *python*))))
 
+(defun raw-py-exec/no-return (&rest strings)
+  "Execute strings without expecting any return, used to pass
+control permanently to, say, a GUI main loop in the python process.
+Passes strings as they are, without any 'pythonize'ation."
+  (python-start-if-not-alive)
+  (let ((stream (uiop:process-info-input *python*))
+        (str (apply #'concatenate 'string strings)))
+    (bt:with-recursive-lock-held (*python-lock*) ; wait for previous processing to be done
+      (write-char #\x stream)
+      (stream-write-string str stream)
+      (force-output stream))))
+
 (declaim (ftype (function (&rest string)) raw-pyeval))
 (defun raw-pyeval (&rest strings)
   "Calls python eval on the concatenation of strings, as they are, without any


### PR DESCRIPTION
This is about #34 .  This is a working sketch of what one has to do to integrate a GUI loop running in the python process main thread.  I am a little worried about the stdin/stdout/stderr getting stomped on because things are running now continuously and outputting, but I think because we redefine stdout we should be safe.

Nominally now we can also support python calling callbacks in the lisp process asynchronously.