### PR TITLE
Add support for asynchronous callbacks, python polling of lisp, multiple python processes

### DIFF
--- a/.config
+++ b/.config
@@ -1,1 +1,1 @@
-{"printPythonTraceback":true,"pycmd":"/usr/bin/python3","numpyPickleLocation":"tmp","numpyPickleLowerBound":300}
+{"pycmd":"/usr/bin/python3","numpyPickleLocation":"/tmp/","numpyPickleLowerBound":100,"printPythonTraceback":true}

--- a/.config
+++ b/.config
@@ -1,1 +1,1 @@
-{"printPythonTraceback":true,"pycmd":"python3","numpyPickleLocation":"tmp","numpyPickleLowerBound":100000}
+{"printPythonTraceback":true,"pycmd":"lib/.venv/bin/python","numpyPickleLocation":"tmp","numpyPickleLowerBound":300}

--- a/.config
+++ b/.config
@@ -1,1 +1,1 @@
-{"printPythonTraceback":true,"pycmd":"lib/.venv/bin/python","numpyPickleLocation":"tmp","numpyPickleLowerBound":300}
+{"printPythonTraceback":true,"pycmd":"/usr/bin/python3","numpyPickleLocation":"tmp","numpyPickleLowerBound":300}

--- a/PyQt6_example.py
+++ b/PyQt6_example.py
@@ -1,0 +1,27 @@
+# This is an example of running a GUI application in Python
+# while still having interaction to the running Lisp REPL.
+# We poll for messages from the REPL, like how Jupyter
+# notebooks work.
+# Run me as:
+# (raw-py-exec/no-return "import PyQt6_example; PyQt6_example.start_app(try_process_message);")
+def start_app (try_process_message):
+        import PyQt6
+        import sys
+        import matplotlib
+        import matplotlib.pyplot as plt
+        from PyQt6.QtWidgets import QApplication
+        from PyQt6.QtCore import QTimer
+        app = QApplication(sys.argv)
+
+        matplotlib.use("QtAgg")
+        plot = plt.plot([1, 2, 3],[4, 5, 6])
+        plt.show(block=False)
+
+        timer = QTimer()
+        def process_messages():
+                try_process_message(blocking=False)
+        timer.timeout.connect(process_messages);
+        timer.start(100);
+        print("Going into main loop, will return when all windows closed")
+        app.exec()
+        print("No more windows, returning to default messsage_dispatch_loop")

--- a/README.md
+++ b/README.md
@@ -49,5 +49,34 @@ Please test using [py4cl2-tests](https://github.com/digikar99/py4cl2-tests).
 
 <img margin="auto" width="75%" src="./docs/readme_matplotlib.png"></img>
 
-Great thanks to [Ben Dudson](https://github.com/bendudson) for starting this project, and documenting it enough to make it more-buildable!
+# eval and exec
 
+`pyexec` uses the Python exec function, which takes a Python statement.
+`pyeval` uses the Python eval function, which takes a Python expression.
+
+When pyexec or pyeval'ing strings in your python image, they are all operating within a shared
+global namespace.  So, for example, `(pyexec "import math")` will then make math.sqrt available
+for all future calls, so `(pyeval "math.sqrt(9)")` will return `3`.
+
+# Running py4cl2 with a Python GUI
+
+The example above with matplotlib was a static plot (no interactive zooming, no GUI).  To enable interactivity, the main thread of the Python process needs to be running a GUI main loop.  To do this, we can change the py4cl2 loop to not block and to be called regularly by the gui main loop.  To do so, see the example src/PyQt6_example.py where we create a matplotlib plot on the Qt6 backend.  To run it, you would do the following:
+```lisp
+  ;; so python can find the example module
+  (pyexec (format nil "import sys; sys.path.insert(0, '~a')"
+                  (directory-namestring
+                   (asdf:component-pathname
+                    (asdf:find-component :py4cl2 "python-code")))))
+  ;; start the gui loop and a simple plot.
+  (raw-py-exec/no-return "import PyQt6_example; PyQt6_example.start_app(try_process_message);")
+  (pyeval "1 + 1") ;; still works despite GUI refreshing as needed
+```
+
+# Multiple Python processes
+
+You can manage multiple running python processes.  By default there is
+a dynamic variable `*python*` bound to the running process.  If you
+want to create a new one, call `(pystart)` and `(let ((*python*
+my-python))` around your calls.
+
+Great thanks to [Ben Dudson](https://github.com/bendudson) for starting this project, and documenting it enough to make it more-buildable!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
->This is a fork of bendudson/py4cl.
+>This is a fork of [digikar99/py4cl2](https://github.com/digikar99/py4cl2)
 
 # Github Pages
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The example above with matplotlib was a static plot (no interactive zooming, no 
   (raw-py-exec/no-return "import PyQt6_example; PyQt6_example.start_app(try_process_message);")
   (pyeval "1 + 1") ;; still works despite GUI refreshing as needed
 ```
+See [cl-matplotlib](https://github.com/ajberkley/cl-matplotlib) for an example that uses this version of py4cl2 to have a nice interactive plotting gui running in tandem with our Common Lisp REPL.
 
 # Multiple Python processes
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
->This is a fork of [digikar99/py4cl2](https://github.com/digikar99/py4cl2)
+>This is a fork of bendudson/py4cl.
 
 # Github Pages
 
@@ -71,7 +71,6 @@ The example above with matplotlib was a static plot (no interactive zooming, no 
   (raw-py-exec/no-return "import PyQt6_example; PyQt6_example.start_app(try_process_message);")
   (pyeval "1 + 1") ;; still works despite GUI refreshing as needed
 ```
-See [cl-matplotlib](https://github.com/ajberkley/cl-matplotlib) for an example that uses this version of py4cl2 to have a nice interactive plotting gui running in tandem with our Common Lisp REPL.
 
 # Multiple Python processes
 

--- a/py4cl.py
+++ b/py4cl.py
@@ -18,6 +18,7 @@ import os
 import signal
 import traceback
 import threading
+import time
 
 numpy_is_installed = False
 try:
@@ -117,9 +118,7 @@ class LispCallbackObject (object):
 			finally:
 				return_values = old_return_values
 
-			# Wait for a value to be returned.
-			# Note that the lisp function may call python before returning
-			return message_dispatch_loop()
+			return try_process_message(blocking=True)
 
 
 class UnknownLispObject (object):
@@ -160,7 +159,7 @@ class UnknownLispObject (object):
 			sys.stdout = output_stream
 
 		# Wait for the result
-		return message_dispatch_loop()
+		return try_process_message(blocking=True) #message_dispatch_loop()
 
 	def __setattr__(self, attr, value):
 		if self.__during_init:
@@ -171,7 +170,7 @@ class UnknownLispObject (object):
 		finally:
 			sys.stdout = output_stream
 		# Wait until finished, to syncronise
-		return message_dispatch_loop()
+		return try_process_message(blocking=True) # message_dispatch_loop()
 
 python_to_lisp_type = {
 	bool       : "BOOLEAN",
@@ -437,20 +436,37 @@ def pythonize(value): # assumes the symbol name is downcased by the lisp process
 	return str(value)[1:].replace("-", "_")
 
 def message_dispatch_loop():
+	while True:
+		try_process_message(blocking=True)
+
+def try_process_message(blocking=True):
 	"""
 	Wait for a message, dispatch on the type of message.
 	Message types are determined by the first character:
 
 	e  Evaluate an expression (expects string)
 	x  Execute a statement (expects string)
+	O  Enable handles
+	o  Disable handles
 	q  Quit
 	"""
 	global return_values  # Controls whether values or handles are returned
+	busy_loop = 100
 	while True:
 		try:
 			output_stream.flush()
+			if not blocking:
+				os.set_blocking(sys.stdin.fileno(), False)
 			# Read command type
 			cmd_type = sys.stdin.read(1)
+			if cmd_type == "":
+				if busy_loop > 0 and not blocking:
+					busy_loop = busy_loop - 1
+					continue;
+				if not blocking:
+					os.set_blocking(sys.stdin.fileno(), True)
+				return None
+			busy_loop = 100
 			# It is possible that python would have finished sending the data to CL
 			# but CL would still not have finished processing. We will receive further
 			# instructions only after CL has finished processing, and therefore we can delete
@@ -471,7 +487,7 @@ def message_dispatch_loop():
 			elif cmd_type == "q":
 				exit(0)
 			elif cmd_type == "r": # return value from lisp function
-				return recv_value()
+				return recv_value() # break out of the while loop
 			elif cmd_type == "O":  # Return only handles
 				return_values += 1
 			elif cmd_type == "o":  # Return values when possible (default)
@@ -488,6 +504,8 @@ def message_dispatch_loop():
 python_objects = {}
 python_handle = itertools.count(0)
 
+# For user to use to give time to our dispatch loop
+eval_globals["try_process_message"] = try_process_message
 # Make callback function accessible to evaluation
 eval_globals["_py4cl_LispCallbackObject"] = LispCallbackObject
 eval_globals["_py4cl_Symbol"] = Symbol

--- a/py4cl.py
+++ b/py4cl.py
@@ -258,16 +258,8 @@ if numpy_is_installed: #########################################################
 
 	def load_pickled_ndarray(filename):
 		arr = numpy.load(filename, allow_pickle = True)
+		os.remove(filename)
 		return arr
-
-	def delete_numpy_pickle_arrays():
-		global NUMPY_PICKLE_INDEX
-		while NUMPY_PICKLE_INDEX:
-			NUMPY_PICKLE_INDEX -= 1
-			numpy_pickle_location = config["numpyPickleLocation"] \
-				+ ".from." + str(NUMPY_PICKLE_INDEX)
-			if os.path.exists(numpy_pickle_location):
-				os.remove(numpy_pickle_location)
 
 	numpy_cl_type = {
 		numpy.dtype("int64"): "(cl:quote (cl:signed-byte 64))",
@@ -305,7 +297,7 @@ if numpy_is_installed: #########################################################
 			NUMPY_PICKLE_INDEX += 1
 			with open(numpy_pickle_location, "wb") as f:
 				numpy.save(f, obj, allow_pickle = True)
-			array = "#.(numpy-file-format:load-array \"" + numpy_pickle_location + "\")"
+			array = "#.(progn (numpy-file-format:load-array \"" + numpy_pickle_location + "\") (uiop:delete-file-if-exists \"" + numpy_pickle_location + "\")"
 			return array
 		if obj.ndim == 0:
 			# Convert to scalar then lispify
@@ -477,11 +469,6 @@ def try_process_message(blocking=True):
 				else:
 					continue; # should not happen
 			busy_loop = 100
-			# It is possible that python would have finished sending the data to CL
-			# but CL would still not have finished processing. We will receive further
-			# instructions only after CL has finished processing, and therefore we can delete
-			# the arrays.
-			if numpy_is_installed: delete_numpy_pickle_arrays()
 
 			if cmd_type == "e":  # Evaluate an expression
 				(string, id, length) = recv_string_with_id()

--- a/py4cl.py
+++ b/py4cl.py
@@ -297,7 +297,7 @@ if numpy_is_installed: #########################################################
 			NUMPY_PICKLE_INDEX += 1
 			with open(numpy_pickle_location, "wb") as f:
 				numpy.save(f, obj, allow_pickle = True)
-			array = "#.(progn (numpy-file-format:load-array \"" + numpy_pickle_location + "\") (uiop:delete-file-if-exists \"" + numpy_pickle_location + "\")"
+			array = "#.(py4cl2::read-and-delete-numpy-file \"" + numpy_pickle_location + "\")"
 			return array
 		if obj.ndim == 0:
 			# Convert to scalar then lispify

--- a/py4cl.py
+++ b/py4cl.py
@@ -381,6 +381,11 @@ def generator(function, stop_value):
 
 ##################################################################
 
+def recv_string_with_id ():
+	id = int(sys.stdin.readline())
+	length = int(sys.stdin.readline())
+	return (sys.stdin.read(length), id, length)
+
 def recv_string():
 	"""
 	Get a string from the input stream
@@ -396,12 +401,14 @@ def recv_value():
 	return eval(recv_string(), eval_globals)
 
 send_value_lock = threading.RLock()
-def send_value(cmd_type, value):
+def send_value(cmd_type, value, response_id=None):
 	"""
 	Send a value to stdout as a string, with length of string first
 	"""
 	with send_value_lock:
 		return_stream.write(cmd_type)
+		if response_id:
+			print(response_id, file = return_stream)
 		try:
 			# if type(value) == str and return_values > 0:
 			# value_str = value # to handle stringified-errors along with remote-objects
@@ -416,17 +423,16 @@ def send_value(cmd_type, value):
 		return_stream.write(value_str)
 		return_stream.flush()
 
-def return_value(value):
+def return_value(value, response_id=-1):
 	"""
 	Return value to lisp process, by writing to return_stream
 	"""
 	if isinstance(value, Exception):
 		return return_error(value)
-	# return_stream.flush() # TODO not sure
-	send_value("r", value)
+	send_value("r", value, response_id=response_id)
 
-def return_error(error):
-	send_value("e", error)
+def return_error(error, response_id=-1):
+	send_value("e", error, response_id=response_id)
 
 def pythonize(value): # assumes the symbol name is downcased by the lisp process
 	"""
@@ -454,33 +460,35 @@ def try_process_message(blocking=True):
 	busy_loop = 100
 	while True:
 		try:
+			response_id = -1
 			output_stream.flush()
 			if not blocking:
 				os.set_blocking(sys.stdin.fileno(), False)
 			# Read command type
 			cmd_type = sys.stdin.read(1)
 			if cmd_type == "":
-				if busy_loop > 0 and not blocking:
-					busy_loop = busy_loop - 1
-					continue;
 				if not blocking:
-					os.set_blocking(sys.stdin.fileno(), True)
-				return None
+					if busy_loop > 0:
+						busy_loop = busy_loop - 1
+						continue;
+					else:
+						os.set_blocking(sys.stdin.fileno(), True)
+					return None
+				else:
+					continue; # should not happen
 			busy_loop = 100
 			# It is possible that python would have finished sending the data to CL
 			# but CL would still not have finished processing. We will receive further
 			# instructions only after CL has finished processing, and therefore we can delete
-			# the arrays. (TODO: But how does this happen with callbacks?)
+			# the arrays.
 			if numpy_is_installed: delete_numpy_pickle_arrays()
 
 			if cmd_type == "e":  # Evaluate an expression
-				expr = recv_string()
-				# if expr not in cache:
-				# print("Adding " + expr + " to cache")
-				# cache[expr] = eval("lambda : " + expr, eval_globals)
-				# result = cache[expr]()
-				result = eval(expr, eval_globals)
-				return_value(result)
+				(string, id, length) = recv_string_with_id()
+				# print(f"Got an E with ID {id} length {length} string {string}")
+				response_id = id
+				result = eval(string, eval_globals)
+				return_value(result, id)
 			elif cmd_type == "x": # Execute a statement
 				exec(recv_string(), eval_globals)
 				return_value(None)
@@ -498,7 +506,7 @@ def try_process_message(blocking=True):
 			# output_stream.write("Python interrupted!\n")
 			return_value(None)
 		except Exception as e:
-			return_error(e)
+			return_error(e, response_id=response_id)
 
 # Store for python objects which cannot be translated to Lisp objects
 python_objects = {}

--- a/py4cl.py
+++ b/py4cl.py
@@ -399,7 +399,7 @@ def send_value(cmd_type, value, response_id=None):
 	"""
 	with send_value_lock:
 		return_stream.write(cmd_type)
-		if response_id:
+		if response_id is not None:
 			print(response_id, file = return_stream)
 		try:
 			# if type(value) == str and return_values > 0:

--- a/src/callpython.lisp
+++ b/src/callpython.lisp
@@ -39,92 +39,172 @@
   (stream-write-value value stream)
   (force-output stream))
 
-(defun dispatch-messages (process)
-  "Read response from python, loop to handle any callbacks"
-  (let ((*python-process-busy-p* t))
-    (handler-case
-        (let* ((read-stream (uiop:process-info-output process))
-               (write-stream (uiop:process-info-input process))
-               (return-value
-                 (loop
-                   ;; First character is type of message
-                   :for message-char := (read-char read-stream)
-                   :do
-                      (case message-char
-                        (#\r (return (stream-read-value read-stream))) ; Returned value
+(defmacro cp-debug-print (&rest rest)
+  (declare (ignorable rest))
+  #+debug `(format *standard-output* ,@rest))
 
-                        (#\e (error 'pyerror
-                                    :text (stream-read-string read-stream)))
-                        ;; Delete object. This is called when an UnknownLispObject is deleted
-                        (#\d (free-handle (stream-read-value read-stream)))
+(defun dispatch-messages (output-stream input-stream)
+  "Read response from python, loop to handle any callbacks.  Returns
+ either objects or delays (lambda ()) -> somethings.  Will potentially
+ also talk back to python for reading and writing slots in lisp
+ objects.  input-stream goes to python, output-stream comes from
+ python.  Call me with the interaction-lock!  Returns
+ (values result result-occurred-if-result-nil)"
+  (loop
+    ;; First character is type of message
+    :for message-char := (read-char output-stream)
+    :do
+       (cp-debug-print "DP: dispatch on '~A'~%" message-char)
+       (return
+         (case message-char
+           (#\r (return			; Returned value
+		  (let ((res (stream-read-value output-stream)))
+                    ;; Careful this print can cause a python object
+                    ;; to be printed, which will cause issues.
+		    (cp-debug-print "DP: ~A~%" res)
+                    (cp-debug-print "DP: Returning it~%")
+		    (values res t))))
+           (#\e (let ((text (stream-read-string output-stream)))
+                  (cp-debug-print "DP: got error ~A~%" text)
+		  (return (lambda () (error 'pyerror :text text)))))
+           (#\d
+            ;; Delete object. This is called when an UnknownLispObject is deleted
+	    (free-handle (stream-read-value output-stream))
+            (values))
+           (#\s ;; Slot read
+	    (destructuring-bind (handle slot-name)
+                (stream-read-value output-stream)
+              (let ((object (lisp-object handle)))
+                ;; User must register a function to handle slot access
+                (dispatch-reply
+                 input-stream
+                 (restart-case
+                     (python-getattr object slot-name)
+                   ;; Provide some restarts for missing handler or missing slot
+		   (return-nil () (values nil t))
+                   (return-zero () 0)
+                   (enter-value (return-value)
+                     :report "Provide a value to return"
+                     :interactive (lambda ()
+                                    (format t "Enter a value to return: ")
+                                    (list (read)))
+		     (values return-value t)))))))
+           (#\S ;; Slot write
+	    (destructuring-bind (handle slot-name slot-value)
+                (stream-read-value output-stream)
+              (let ((object (lisp-object handle)))
+                ;; User must register a function to handle slot write
+                (python-setattr object slot-name slot-value)
+                (dispatch-reply input-stream nil))
+              (values)))
+           (#\c ;; Callback. Return a list, containing function ID, then the args
+	    (cp-debug-print "DP: callback~%")
+            (let* ((call-value (stream-read-value output-stream))
+		   (_ (cp-debug-print "DP: calling ~A~%" call-value))
+                   (return-value (apply (lisp-object (first call-value))
+                                        (if (and (stringp (second call-value))
+                                                 (string= "()" (second call-value)))
+                                            ()
+                                            (second call-value)))))
+	      (declare (ignore _))
+	      (cp-debug-print "DP: callback returned ~A~%" return-value)
+	      (dispatch-reply input-stream return-value)
+	      (cp-debug-print "DP: done~%")
+              (values)))
+           (#\p				; Print stdout
+            (let ((print-string (stream-read-value output-stream)))
+	      (lambda () (princ print-string))))
+           (otherwise (lambda () (error "Unhandled message type '~d'" message-char)))))))
 
-                        ;; Slot read
-                        (#\s (destructuring-bind (handle slot-name)
-                                 (stream-read-value read-stream)
-                               (let ((object (lisp-object handle)))
-                                 ;; User must register a function to handle slot access
-                                 (dispatch-reply
-                                  write-stream
-                                  (restart-case
-                                      (python-getattr object slot-name)
-                                    ;; Provide some restarts for missing handler or missing slot
-                                    (return-nil () nil)
-                                    (return-zero () 0)
-                                    (enter-value (return-value)
-                                      :report "Provide a value to return"
-                                      :interactive (lambda ()
-                                                     (format t "Enter a value to return: ")
-                                                     (list (read)))
-                                      return-value))))))
 
-                        ;; Slot write
-                        (#\S (destructuring-bind (handle slot-name slot-value)
-                                 (stream-read-value read-stream)
-                               (let ((object (lisp-object handle)))
-                                 ;; User must register a function to handle slot write
-                                 (python-setattr object slot-name slot-value)
-                                 (dispatch-reply write-stream nil))))
+(defmacro with-timing (&rest body)
+  (let ((g (gensym)))
+    `(let ((,g (/ (get-internal-real-time) internal-time-units-per-second 1f0)))
+       (labels ((current-time ()
+                  (- (/ (get-internal-real-time) internal-time-units-per-second 1f0) ,g)))
+         ,@body))))
 
-                        (#\c ;; Callback. Return a list, containing function ID, then the args
-                         (let* ((call-value (stream-read-value read-stream))
-                                (return-value (apply (lisp-object (first call-value))
-                                                     (if (and (stringp (second call-value))
-                                                              (string= "()" (second call-value)))
-                                                         ()
-                                                         (second call-value)))))
-                           (dispatch-reply write-stream return-value)))
+(defstruct timing-info
+  (calls 0 :type (unsigned-byte 32))
+  (total-time 0f0 :type single-float))
 
-                        (#\p                ; Print stdout
-                         (let ((print-string (stream-read-value read-stream)))
-                           (princ print-string)))
-                        (otherwise (error "Unhandled message type '~d'" message-char))))))
-          return-value)
-      (end-of-file (condition)
-        (declare (ignore condition))
-        (sleep 0.00001)
-        (error (if (python-alive-p process)
-                   'python-eof-but-alive
-                   'python-eof-and-dead)
-               :python-process process)))))
+
+(defparameter *timing* (make-timing-info))
+
+(defun add-to-timing (time &optional (timing *timing*))
+  (incf (timing-info-calls timing))
+  (incf (timing-info-total-time timing) time)
+  (values))
+
+(defun print-timing (&optional (timing *timing*))
+  (format t "~A calls in ~,3f seconds: ~,1f calls/second~%"
+          (timing-info-calls timing)
+          (timing-info-total-time timing)
+          (/ (timing-info-calls timing)
+             (timing-info-total-time timing))))
+
+(defvar *holding-interaction-lock-already* nil)
+
+(defmacro with-raw-py-lock (python &body body)
+  `(labels ((body () ,@body))
+     (if *holding-interaction-lock-already*
+         (body)
+         (bt:with-recursive-lock-held ((python-raw-py-lock ,python))
+           (body)))))
 
 ;; ============================== RAW FUNCTIONS ================================
-(defvar *python-lock* (bt:make-recursive-lock "py4cl2"))
-
-(declaim (ftype (function (character &rest string)) raw-py))
 (defun raw-py (cmd-char &rest strings)
   "Intended as an abstraction to RAW-PYEVAL and RAW_PYEXEC.
 Passes strings as they are, without any 'pythonize'ation."
   (python-start-if-not-alive)
-  (let ((stream (uiop:process-info-input *python*))
-        (str (apply #'concatenate 'string strings)))
-    (bt:with-recursive-lock-held (*python-lock*) ; wait for previous processing to be done
+  (with-timing
+      (multiple-value-prog1
+          (let* ((python *python*)
+	         (stream (python-input python))
+	         (str (apply #'concatenate 'string strings))
+	         (lock (python-interaction-lock python)))
+            (cp-debug-print "RP: Grabbing raw-py lock ~A~%" lock)
+            (with-raw-py-lock python
+              (cp-debug-print "RP: ~A ~A -> PYTHON~%" cmd-char strings)
+              (cp-debug-print "RP: Grabbing interaction lock ~A~%" lock)
+              (bt:with-recursive-lock-held (lock) ; wait for previous processing to be done
+	        (unless (null (python-interaction-results python))
+		  (format *standard-output* "Unexpected results from python process ~A~%" (python-interaction-results python))
+		  (map nil (lambda (x)
+			     (when (functionp x)
+			       (restart-case
+				   (funcall x)
+			         (IGNORE ()))))
+		       (python-interaction-results python))
+		  (setf (python-interaction-results python) nil))
+                (setf (python-lispifiers python) *lispifiers*)
+                (setf (python-pythonizers python) *pythonizers*)
       (write-char cmd-char stream)
       (stream-write-string str stream)
-      (force-output stream)
+                (force-output stream))
+              (cp-debug-print "RP: Release interaction lock and now getting results~%")
       ;; wait for python output
-      (dispatch-messages *python*))))
+              (get-results python)))
+        (add-to-timing (current-time)))))
 
-(declaim (ftype (function (&rest string)) raw-pyeval))
+(defun raw-py-exec/no-return (&rest strings)
+  "Execute strings without expecting any return, used to pass
+control permanently to, say, a GUI main loop in the python process.
+Passes strings as they are, without any 'pythonize'ation."
+  (python-start-if-not-alive)
+    (let* ((python *python*)
+	   (stream (python-input python))
+           (str (apply #'concatenate 'string strings)))
+      (bt:with-recursive-lock-held ((python-raw-py-lock *python*))
+        (cp-debug-print "RP: raw-py-exec/no-return ~A~%" strings)
+        (bt:with-recursive-lock-held ((python-interaction-lock python))
+          (cp-debug-print "RP: raw-py-exec/no-return got lock~%")
+          (write-char #\x stream)
+          (stream-write-string str stream)
+          (force-output stream))
+        (cp-debug-print "RP: released interaction lock~%"))
+      (cp-debug-print "RP: released raw-py lock~%")))
+
 (defun raw-pyeval (&rest strings)
   "Calls python eval on the concatenation of strings, as they are, without any
 pythonization or modification."
@@ -134,7 +214,6 @@ pythonization or modification."
       (apply #'raw-pyexec strings)
       (values))))
 
-(declaim (ftype (function (&rest string)) raw-pyexec))
 (defun raw-pyexec (&rest strings)
   "Calls python exec on the concatenation of strings, as they are, without any
 pythonization or modification.
@@ -306,9 +385,10 @@ Note: FUN-NAME is NOT PYTHONIZEd if it is a string.
   "Ensures that all values returned by python functions
 and methods are kept in python, and only handles returned to lisp.
 This is useful if performing operations on large datasets."
-  `(let ()
+  `(progn
      (python-start-if-not-alive)
-     (let ((stream (uiop:process-info-input *python*)))
+     ;; Oh oh!  Not allowed
+     (let ((stream (python-input *python*)))
        (write-char #\O stream)        ;; Turn on remote objects
        (force-output stream)
        (unwind-protect

--- a/src/callpython.lisp
+++ b/src/callpython.lisp
@@ -43,9 +43,6 @@
   (declare (ignorable rest))
   #+debug `(format *standard-output* ,@rest))
 
-(defstruct python-error
-  thunk)
-
 (defun dispatch-messages (output-stream input-stream)
   "Read response from python, loop to handle any callbacks.  Returns
  either objects or delays (lambda ()) -> somethings.  Will potentially

--- a/src/callpython.lisp
+++ b/src/callpython.lisp
@@ -43,41 +43,26 @@
   (declare (ignorable rest))
   #+debug `(format *standard-output* ,@rest))
 
-(defun dispatch-messages (output-stream input-stream)
-  "Read response from python, loop to handle any callbacks.  Returns
- either objects or delays (lambda ()) -> somethings.  Will potentially
- also talk back to python for reading and writing slots in lisp
- objects.  input-stream goes to python, output-stream comes from
- python.  Call me with the interaction-lock!  Returns
- (values result result-occurred-if-result-nil)"
+(defun dispatch (python python-message)
   (loop
-    ;; First character is type of message
-    :for message-char := (read-char output-stream)
+    for message-char = (python-message-cmd-char python-message)
+    for string = (python-message-string python-message)
     :do
        (cp-debug-print "DP: dispatch on '~A'~%" message-char)
        (return
          (case message-char
-           (#\r (return			; Returned value
-		  (let ((res (stream-read-value output-stream)))
-                    ;; Careful this print can cause a python object
-                    ;; to be printed, which will cause issues.
-		    (cp-debug-print "DP: ~A~%" res)
-                    (cp-debug-print "DP: Returning it~%")
-		    (values res t))))
-           (#\e (let ((text (stream-read-string output-stream)))
-                  (cp-debug-print "DP: got error ~A~%" text)
-		  (return (make-python-error :thunk (lambda () (error 'pyerror :text text))))))
-           (#\d
-            ;; Delete object. This is called when an UnknownLispObject is deleted
-	    (free-handle (stream-read-value output-stream))
+           (#\r (return (values (read-value string) t)))
+           (#\e (return (values (make-python-error :thunk (lambda () (error 'pyerror :text string))) t)))
+           (#\d ;; Delete object. This is called when an UnknownLispObject is deleted
+	    (free-handle (read-value string))
             (values))
            (#\s ;; Slot read
 	    (destructuring-bind (handle slot-name)
-                (stream-read-value output-stream)
+                (read-value string)
               (let ((object (lisp-object handle)))
                 ;; User must register a function to handle slot access
                 (dispatch-reply
-                 input-stream
+                 (python-input python)
                  (with-sldb-default-restart return-nil
                    (restart-case
                        (python-getattr object slot-name)
@@ -92,35 +77,32 @@
 		       (values return-value t))))))))
            (#\S ;; Slot write
 	    (destructuring-bind (handle slot-name slot-value)
-                (stream-read-value output-stream)
+                (read-value string)
               (let ((object (lisp-object handle)))
                 ;; User must register a function to handle slot write
                 (python-setattr object slot-name slot-value)
-                (dispatch-reply input-stream nil))
+                (dispatch-reply (python-input python) nil))
               (values)))
            (#\c ;; Callback. Return a list, containing function ID, then the args
-	    (cp-debug-print "DP: callback~%")
-            (let* ((call-value (stream-read-value output-stream))
-		   (_ (cp-debug-print "DP: calling ~A~%" call-value))
-                   (return-value
-                     (with-sldb-default-restart ignore
-                       (restart-case
-                           (apply (lisp-object (first call-value))
-                                  (if (and (stringp (second call-value))
-                                           (string= "()" (second call-value)))
-                                      ()
-                                      (second call-value)))
-                         (ignore () nil)))))
-	      (declare (ignore _))
-	      (cp-debug-print "DP: callback returned ~A~%" return-value)
-	      (dispatch-reply input-stream return-value)
-	      (cp-debug-print "DP: done~%")
-              (values)))
+            (let ((*lispifiers* (python-lispifiers python))
+                  (*pythonizers* (python-pythonizers python)))
+              (let* ((call-value (read-value string))
+                     (return-value
+                       (with-sldb-default-restart ignore
+                         (restart-case
+                             (apply (lisp-object (first call-value))
+                                    (if (and (stringp (second call-value))
+                                             (string= "()" (second call-value)))
+                                        ()
+                                        (second call-value)))
+                           (ignore () nil)))))
+	        (dispatch-reply (python-input python) return-value)
+                (values))))
            (#\p				; Print stdout
-            (let ((print-string (stream-read-value output-stream)))
+            (let ((print-string (read-value string)))
 	      (lambda () (princ print-string))))
-           (otherwise (make-python-error :thunk (lambda () (error "Unhandled message type '~d'" message-char))))))))
-
+           (otherwise
+            (values (make-python-error :thunk (lambda () (error "Unhandled message type '~d'" message-char))) t))))))
 
 (defmacro with-timing (&rest body)
   (let ((g (gensym)))
@@ -132,7 +114,6 @@
 (defstruct timing-info
   (calls 0 :type (unsigned-byte 32))
   (total-time 0f0 :type single-float))
-
 
 (defparameter *timing* (make-timing-info))
 
@@ -148,48 +129,19 @@
           (/ (timing-info-calls timing)
              (timing-info-total-time timing))))
 
-(defvar *holding-interaction-lock-already* nil)
-
-(defmacro with-raw-py-lock (python &body body)
-  `(labels ((body () ,@body))
-     (if *holding-interaction-lock-already*
-         (body)
-         (bt:with-recursive-lock-held ((python-raw-py-lock ,python))
-           (body)))))
-
 ;; ============================== RAW FUNCTIONS ================================
 (defun raw-py (cmd-char &rest strings)
   "Intended as an abstraction to RAW-PYEVAL and RAW_PYEXEC.
 Passes strings as they are, without any 'pythonize'ation."
   (python-start-if-not-alive)
   (with-timing
-      (multiple-value-prog1
-          (let* ((python *python*)
-	         (stream (python-input python))
-	         (str (apply #'concatenate 'string strings))
-	         (lock (python-interaction-lock python)))
-            (cp-debug-print "RP: Grabbing raw-py lock ~A~%" lock)
-            (with-raw-py-lock python
-              (cp-debug-print "RP: ~A ~A -> PYTHON~%" cmd-char strings)
-              (cp-debug-print "RP: Grabbing interaction lock ~A~%" lock)
-              (bt:with-recursive-lock-held (lock) ; wait for previous processing to be done
-	        (unless (null (python-interaction-results python))
-		  (format *standard-output* "Unexpected results from python process ~A~%" (python-interaction-results python))
-		  (map nil (lambda (x)
-			     (when (python-error-p x)
-			       (restart-case
-				   (funcall (python-error-thunk x))
-			         (IGNORE ()))))
-		       (python-interaction-results python))
-		  (setf (python-interaction-results python) nil))
-                (setf (python-lispifiers python) *lispifiers*)
-                (setf (python-pythonizers python) *pythonizers*)
-                (write-char cmd-char stream)
-                (stream-write-string str stream)
-                (force-output stream))
-              (cp-debug-print "RP: Release interaction lock and now getting results~%")
-              ;; wait for python output
-              (get-results python)))
+      (prog1
+          (let ((r (make-request *python* cmd-char (apply #'concatenate 'string strings))))
+            (if (python-error-p r)
+                (restart-case
+                    (funcall (python-error-thunk r))
+                  (IGNORE ()))
+                r))
         (add-to-timing (current-time)))))
 
 (defun raw-py-exec/no-return (&rest strings)
@@ -197,18 +149,13 @@ Passes strings as they are, without any 'pythonize'ation."
 control permanently to, say, a GUI main loop in the python process.
 Passes strings as they are, without any 'pythonize'ation."
   (python-start-if-not-alive)
-    (let* ((python *python*)
-	   (stream (python-input python))
-           (str (apply #'concatenate 'string strings)))
-      (bt:with-recursive-lock-held ((python-raw-py-lock *python*))
-        (cp-debug-print "RP: raw-py-exec/no-return ~A~%" strings)
-        (bt:with-recursive-lock-held ((python-interaction-lock python))
-          (cp-debug-print "RP: raw-py-exec/no-return got lock~%")
-          (write-char #\x stream)
-          (stream-write-string str stream)
-          (force-output stream))
-        (cp-debug-print "RP: released interaction lock~%"))
-      (cp-debug-print "RP: released raw-py lock~%")))
+  (let* ((python *python*)
+	 (stream (python-input python))
+         (str (apply #'concatenate 'string strings)))
+    (bt:with-recursive-lock-held ((python-interaction-lock python))
+      (write-char #\x stream)
+      (stream-write-string str stream)
+      (force-output stream))))
 
 (defun raw-pyeval (&rest strings)
   "Calls python eval on the concatenation of strings, as they are, without any
@@ -388,18 +335,19 @@ Note: FUN-NAME is NOT PYTHONIZEd if it is a string.
 
 (defmacro with-remote-objects (&body body)
   "Ensures that all values returned by python functions
-and methods are kept in python, and only handles returned to lisp.
-This is useful if performing operations on large datasets."
+ and methods are kept in python, and only handles returned to lisp.
+ This is useful if performing operations on large datasets."
   `(progn
      (python-start-if-not-alive)
-     ;; Oh oh!  Not allowed
      (let ((stream (python-input *python*)))
-       (write-char #\O stream)        ;; Turn on remote objects
-       (force-output stream)
+       (bt:with-recursive-lock-held ((python-interaction-lock python))
+         (write-char #\O stream)        ;; Turn on remote objects
+         (force-output stream))
        (unwind-protect
             (progn ,@body)
-         (write-char #\o stream)          ;; Turn off remote objects
-         (force-output stream)))))
+         (bt:with-recursive-lock-held ((python-interaction-lock python))
+           (write-char #\o stream)          ;; Turn off remote objects
+           (force-output stream))))))
 
 (defmacro with-remote-objects* (&body body)
   "Ensures that all values returned by python functions

--- a/src/callpython.lisp
+++ b/src/callpython.lisp
@@ -201,14 +201,12 @@ Eg.
   25"
     (python-start-if-not-alive)
     (delete-freed-python-objects) ; delete before pythonizing
-    (delete-numpy-pickle-arrays)
     (apply #'raw-pyeval (mapcar #'pythonize-if-needed args)))
 
   (defun pyexec (&rest args)
     "Calls python exec on args; PYTHONIZEs arg if it satisfies PYTHONIZEP."
     (python-start-if-not-alive)
     (delete-freed-python-objects) ; delete before pythonizing
-    (delete-numpy-pickle-arrays)
     (apply #'raw-pyexec (mapcar #'pythonize-if-needed args)))
 
   ;; One argument for the name (setf pyeval) is that it sets the "place" returned

--- a/src/callpython.lisp
+++ b/src/callpython.lisp
@@ -187,11 +187,11 @@ Passes strings as they are, without any 'pythonize'ation."
 		  (setf (python-interaction-results python) nil))
                 (setf (python-lispifiers python) *lispifiers*)
                 (setf (python-pythonizers python) *pythonizers*)
-      (write-char cmd-char stream)
-      (stream-write-string str stream)
+                (write-char cmd-char stream)
+                (stream-write-string str stream)
                 (force-output stream))
               (cp-debug-print "RP: Release interaction lock and now getting results~%")
-      ;; wait for python output
+              ;; wait for python output
               (get-results python)))
         (add-to-timing (current-time)))))
 

--- a/src/callpython.lisp
+++ b/src/callpython.lisp
@@ -43,6 +43,9 @@
   (declare (ignorable rest))
   #+debug `(format *standard-output* ,@rest))
 
+(defstruct python-error
+  thunk)
+
 (defun dispatch-messages (output-stream input-stream)
   "Read response from python, loop to handle any callbacks.  Returns
  either objects or delays (lambda ()) -> somethings.  Will potentially
@@ -66,7 +69,7 @@
 		    (values res t))))
            (#\e (let ((text (stream-read-string output-stream)))
                   (cp-debug-print "DP: got error ~A~%" text)
-		  (return (lambda () (error 'pyerror :text text)))))
+		  (return (make-python-error :thunk (lambda () (error 'pyerror :text text))))))
            (#\d
             ;; Delete object. This is called when an UnknownLispObject is deleted
 	    (free-handle (stream-read-value output-stream))
@@ -114,7 +117,7 @@
            (#\p				; Print stdout
             (let ((print-string (stream-read-value output-stream)))
 	      (lambda () (princ print-string))))
-           (otherwise (lambda () (error "Unhandled message type '~d'" message-char)))))))
+           (otherwise (make-python-error :thunk (lambda () (error "Unhandled message type '~d'" message-char))))))))
 
 
 (defmacro with-timing (&rest body)
@@ -171,9 +174,9 @@ Passes strings as they are, without any 'pythonize'ation."
 	        (unless (null (python-interaction-results python))
 		  (format *standard-output* "Unexpected results from python process ~A~%" (python-interaction-results python))
 		  (map nil (lambda (x)
-			     (when (functionp x)
+			     (when (python-error-p x)
 			       (restart-case
-				   (funcall x)
+				   (funcall (python-error-thunk x))
 			         (IGNORE ()))))
 		       (python-interaction-results python))
 		  (setf (python-interaction-results python) nil))

--- a/src/callpython.lisp
+++ b/src/callpython.lisp
@@ -81,17 +81,18 @@
                 ;; User must register a function to handle slot access
                 (dispatch-reply
                  input-stream
-                 (restart-case
-                     (python-getattr object slot-name)
-                   ;; Provide some restarts for missing handler or missing slot
-		   (return-nil () (values nil t))
-                   (return-zero () 0)
-                   (enter-value (return-value)
-                     :report "Provide a value to return"
-                     :interactive (lambda ()
-                                    (format t "Enter a value to return: ")
-                                    (list (read)))
-		     (values return-value t)))))))
+                 (with-sldb-default-restart return-nil
+                   (restart-case
+                       (python-getattr object slot-name)
+                     ;; Provide some restarts for missing handler or missing slot
+		     (return-nil () (values nil t))
+                     (return-zero () 0)
+                     (enter-value (return-value)
+                       :report "Provide a value to return"
+                       :interactive (lambda ()
+                                      (format t "Enter a value to return: ")
+                                      (list (read)))
+		       (values return-value t))))))))
            (#\S ;; Slot write
 	    (destructuring-bind (handle slot-name slot-value)
                 (stream-read-value output-stream)
@@ -104,11 +105,15 @@
 	    (cp-debug-print "DP: callback~%")
             (let* ((call-value (stream-read-value output-stream))
 		   (_ (cp-debug-print "DP: calling ~A~%" call-value))
-                   (return-value (apply (lisp-object (first call-value))
-                                        (if (and (stringp (second call-value))
-                                                 (string= "()" (second call-value)))
-                                            ()
-                                            (second call-value)))))
+                   (return-value
+                     (with-sldb-default-restart ignore
+                       (restart-case
+                           (apply (lisp-object (first call-value))
+                                  (if (and (stringp (second call-value))
+                                           (string= "()" (second call-value)))
+                                      ()
+                                      (second call-value)))
+                         (ignore () nil)))))
 	      (declare (ignore _))
 	      (cp-debug-print "DP: callback returned ~A~%" return-value)
 	      (dispatch-reply input-stream return-value)

--- a/src/callpython.lisp
+++ b/src/callpython.lisp
@@ -337,7 +337,8 @@ Note: FUN-NAME is NOT PYTHONIZEd if it is a string.
  This is useful if performing operations on large datasets."
   `(progn
      (python-start-if-not-alive)
-     (let ((stream (python-input *python*)))
+     (let* ((python *python*)
+            (stream (python-input python)))
        (bt:with-recursive-lock-held ((python-interaction-lock python))
          (write-char #\O stream)        ;; Turn on remote objects
          (force-output stream))

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -45,7 +45,12 @@ For example,
   ; 5        ; lispifier uncalled for non-VECTOR
   5
 
-NOTE: This is a new feature and hence unstable; recommended to avoid in production code."
+NOTE: This is a new feature and hence unstable; recommended to avoid in production code.
+
+WARNING: This applies to any operations that occur within this
+context, but ALSO to any asynchronous callbacks that may occur if you
+are running, say, a GUI in python.  This makes it fundamentally unsafe
+as implemented."
   `(let ((*lispifiers* (list* ,@(loop :for (type lispifier) :in overriding-lispifiers
                                       :collect `(cons ',type ,lispifier))
                               *lispifiers*)))
@@ -69,7 +74,12 @@ For example,
   ; 5        ; pythonizer uncalled for non-VECTOR
   5
 
-NOTE: This is a new feature and hence unstable; recommended to avoid in production code."
+NOTE: This is a new feature and hence unstable; recommended to avoid in production code.
+
+WARNING: This applies to any operations that occur within this
+context, but ALSO to any asynchronous callbacks that may occur if you
+are running, say, a GUI in python.  This makes it fundamentally unsafe
+as implemented."
   `(let ((*pythonizers* (list* ,@(loop :for (type pythonizer) :in overriding-pythonizers
                                        :collect `(cons ',type ,pythonizer))
                                *pythonizers*)))
@@ -83,8 +93,8 @@ NOTE: This is a new feature and hence unstable; recommended to avoid in producti
   ;; This is called from py4cl.py
   (loop :for (type . lispifier) :in *lispifiers*
         :if (typep object type)
-          :do (return-from customize (funcall lispifier object)))
-  object)
+          :do (return (funcall lispifier object))
+        :finally (return object)))
 
 (defun %pythonize (object)
   "A wrapper around PYTHONIZE to take custom *PYTHONIZERS* into account."
@@ -189,7 +199,7 @@ instructions on creating a ram-disk on linux-based systems.
       (format t "~&Call (SAVE-CONFIG) if you'd like to persist this value for PYCMD.
 You will need to (PYSTOP) and (PYSTART) to use the new binary.~%")
       (save-config))
-  (when (python-alive-p) (pycall "_py4cl_load_config")))
+  (when (python-alive-p *python*) (pycall "_py4cl_load_config")))
 
 (defun py-cd (path)
   (pyexec "import os")

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -1,6 +1,6 @@
 (in-package :py4cl2)
 
-(defvar *python* nil "Current active python instance")
+(defvar *python* nil "Current `python' instance")
 
 (defvar *config* () "Configuration variable used to store configuration values for PY4CL2.
 This variable should be manipulated using CONFIG-VAR and (SETF CONFIG-VAR).")

--- a/src/config.lisp
+++ b/src/config.lisp
@@ -1,5 +1,7 @@
 (in-package :py4cl2)
 
+(defvar *python* nil "Current active python instance")
+
 (defvar *config* () "Configuration variable used to store configuration values for PY4CL2.
 This variable should be manipulated using CONFIG-VAR and (SETF CONFIG-VAR).")
 ;; Refer initialize function to note which variables are included under *config*

--- a/src/features.lisp
+++ b/src/features.lisp
@@ -15,8 +15,10 @@ The list can include one or more of:
   :INTERRUPT
 ")
 
-(defun numpy-installed-p ()
-  (handler-case (progn
+(defun numpy-installed-p (&optional (python *python*))
+  (handler-case
+      (let ((*python* python))
+	(declare (special *python*)) ;; compilation order, may not be known
                   (pyexec "import numpy")
                   t)
     (pyerror (condition)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -66,4 +66,5 @@
    #:py-cd)
   (:export
    #:*internal-features*
-   #:*warn-on-unavailable-feature-usage*))
+   #:*warn-on-unavailable-feature-usage*
+   #:raw-py-exec/no-return))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -67,4 +67,5 @@
   (:export
    #:*internal-features*
    #:*warn-on-unavailable-feature-usage*
-   #:raw-py-exec/no-return))
+   #:raw-py-exec/no-return
+   #:*notify-user*))

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -2,27 +2,110 @@
 
 (in-package :py4cl2)
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
+(defvar *python-id* 0
+  "Unique id for each python process.  Used so we can keep track of
+ pickled arrays and also to track objects that we are keeping alive
+ in the python process, so we can free them later (if the python
+ process is restarted, we don't care about them anymore)")
 
-  ;;; The macro below require this to be available - to save us some compile-file warnings
+;; State of a running python process
+;; We use stdin / stdout to communicate with our dispatch loop
+;; stderr is what python thinks stdout is, so on that we capture
+;; printed output and misc error output.
 
-  (defvar *python* nil
-    "Most recently started python subprocess")
 
-  (defvar *current-python-process-id* 0
-    "A number which changes when python is started. This
-is used to prevent garbage collection from deleting objects in the wrong
-python session")
+(defstruct python
+  (subprocess nil)
+  ;; This is for reading stuff coming back on stderr (printed stuff from python)
+  (output-lock (bt:make-recursive-lock) :type bt:lock)
+  (output-thread nil :type (or null bt:thread))
+  ;; gets written to when in #'with-python-output
+  (output-result (make-array 0 :element-type 'character :adjustable t :fill-pointer t) :type vector)
+  ;; This lock deals with reading data back from python
+  (interaction-thread nil :type (or null bt:thread))
+  (interaction-lock (bt:make-recursive-lock) :type bt:lock)
+  (interaction-wait (bt:make-condition-variable :name "stdin stream waitqueue"))
+  (interaction-results nil :type list) ;; for simplicity we lock
+  ;; This is the user facing lock through raw-py.  Having two locks is dangerous
+  ;; one must make sure the interaction-thread NEVER grabs the raw-py lock
+  ;; as the order of locks is RAW-PY then INTERACTION-LOCK.  While the interaction-thread
+  ;; grabs the INTERACTION-LOCK without the RAW-PY lock.  This is the PYTHON-DURING-CALLBACK
+  ;; test
+  (raw-py-lock (bt:make-recursive-lock) :type bt:lock)
+  (in-with-python-output nil :type boolean)
+  (id (incf *python-id*) :type fixnum) ;; unique id
+  (freed-python-objects nil :type list) ;; lisp objects that have been gc'ed, free them from python
+  (numpy-pickle-index 0 :type fixnum)
+  (lisp-objects nil :type list) ;; lisp objects that python might know about
+  (numpy-installed nil :type boolean)
+  (thread-end-signal nil :type boolean) ;; t to gently stop threads
+  (lispifiers nil :type list)
+  (pythonizers nil :type list))
 
-  (defvar *python-process-busy-p* nil
-    "Used by pyinterrupt to determine if python process is waiting for input, or
-is busy processing.
+(defun subprocess (python/subprocess)
+  (if (python-p python/subprocess)
+      (python-subprocess python/subprocess)
+      python/subprocess))
 
-A possible workaround is to use strace.
-See https://askubuntu.com/questions/1118109/how-do-i-tell-if-a-command-is-running-or-waiting-for-user-input")
+(defun python-error-output (python/subprocess)
+  "Works on a `python' object or a python-subprocess.  Returns
+ the error output stream, things printed by the python process"
+  (uiop:process-info-error-output (subprocess python/subprocess)))
 
-  (defvar *py4cl-tests* nil)
+(defun python-output (python/subprocess)
+  "Works on a `python' object or a python-subprocess.  This is the output
+ from the python process dispatch loop."
+  (uiop:process-info-output (subprocess python/subprocess)))
 
+(defun python-input (python/subprocess)
+  "To use this, one must hold the python-lock.  This sends
+ data to the python process"
+  (uiop:process-info-input (subprocess python/subprocess)))
+
+(defun python-alive-p (&optional (python *python*))
+  "Returns non-NIL if the python process is alive
+ (e.g. SBCL -> T, CCL -> RUNNING). Works on a `python'
+ or a python-subprocess thereof"
+  (and python (subprocess python) (uiop:process-alive-p (subprocess python))))
+
+(defmacro pp-debug-print (&rest rest)
+  (declare (ignorable rest))
+  #+debug `(format *standard-output* ,@rest))
+
+(defun get-results& (python)
+  "Block until some results from python.  But cannot block if the
+ interaction thread is calling us."
+  (declare (optimize speed safety))
+  (let ((lock (python-interaction-lock python)))
+    (pp-debug-print "GR: Grabbing interaction lock~%")
+    (bt:with-recursive-lock-held (lock)
+      (pp-debug-print "GR: Got interaction lock~%")
+      (loop
+	for is-result = (python-interaction-results python)
+	for result = (pop (python-interaction-results python))
+	until is-result ;; result may be nil!
+	do
+	   (pp-debug-print "GR: waiting on interaction-wait~%")
+           ;; Here we have a race, because we want to give control
+           ;; back to the interaction thread, but someone else may
+           ;; be in raw-py waiting to grab the interaction lock and
+           ;; if they get it, they will get our results.  But this
+           ;; is prevented by the raw-py lock.
+	   (unless (python-alive-p python)
+	     (error 'python-eof-and-dead :python-process (python-subprocess python) :stream nil))
+	   (bt:condition-wait (python-interaction-wait python) lock :timeout 1)
+	finally
+	   (pp-debug-print "GR: Got result ~S~%" result)
+           ;; It's a delayed error
+           (when (functionp result)
+             (funcall result))
+           (when (python-interaction-results python)
+             (error (format nil "More results than expected: ~A" (pop (python-interaction-results python)))))
+	   (return result)))))
+
+(declaim (type (or null python) *python*))
+(defvar *python* nil "Current `python' instance")
+(defvar *py4cl-tests* nil "Not needed, but here for backwards compatibility")
   ;; We are loading the whole file into a variable, because we want users to be able
   ;; to use py4cl2 even in a dumped lisp image, without any additional configuration.
   (defvar *python-code*
@@ -30,200 +113,300 @@ See https://askubuntu.com/questions/1118109/how-do-i-tell-if-a-command-is-runnin
      (asdf:component-pathname
       (asdf:find-component :py4cl2 "python-code"))))
 
-  (defvar *python-startup-error*)  ; couldn't put this inside the :REPORT!
-
-  (defvar *python-output-semaphore* (bt:make-semaphore))
-  (defvar *python-output-thread*)
-
-  ;;; This is more of a global variable than a dynamic variable.
-  (defvar *in-with-python-output* nil)
-
   (declaim (type list *additional-init-codes*))
   (defvar *additional-init-codes* nil
     "A list of strings each of which should be python code. All the code
-will be executed by PYSTART. The code should not contain single-quotation marks."))
+will be executed by PYSTART. The code should not contain single-quotation marks.")
 
 (define-condition python-process-startup-error (error)
-  ((command :initarg :command :reader command))
+  ((command :initarg :command :initform "" :reader command)
+   (error-string :initarg :error :initform "" :reader error-string))
   (:report (lambda (condition stream)
              (format stream "Unable to start python process \"~a\"~%~% Error: ~%~%~a"
                      (command condition)
-                     *python-startup-error*))))
+		     (error-string condition)))))
 
-(defun pystart (&optional (command (config-var 'pycmd)))
-  "Start a new python subprocess
-This sets the global variable *python* to the process handle,
-in addition to returning it.
-COMMAND is a string with the python executable to launch e.g. \"python\"
-By default this is is set to (CONFIG-VAR 'PYCMD)
-"
-  (flet ((bash-escape-string (string) ; TODO: Better way to do things!
+#+unix
+(defun bash-escape-string (string)
+  (declare (type string string))
            ;; We want strings such as
            ;; "/user/ram-disk/test (hello''/miniconda(3')/bin/"
            ;; to be escaped correctly.
-           ;; This function only exists in the context of PYSTART
-           (with-output-to-string (*standard-output*)
-             (iter (for ch in-string string)
+  (with-output-to-string (str)
+    (labels ((escape-char (ch)
                (case ch
-                 (#\' (write-string "\\'"))
-                 (#\( (write-string "\\("))
-                 (#\) (write-string "\\)"))
-                 (#\space (write-string "\\ "))
-                 (t (write-char ch)))))))
-    (declare (ignorable (function bash-escape-string)))
-    (setf *python-lock* (bt:make-recursive-lock))
-    (loop :until (python-alive-p)
-          :do (setq *python*
-                    #+(or os-windows windows)
-                    (uiop:launch-program
-                     (concatenate 'string
-                                  "set OLDPYTHONIOENCODING=PYTHONIOENCODING && set PYTHONIOENCODING=utf8 && "
-                                  command
-                                  " -u "
-                                  (namestring
-                                   (asdf:component-pathname
-                                    (asdf:find-component
-                                     :py4cl2 "python-code")))
-                                  " "
-                                  (directory-namestring
-                                   (asdf:component-pathname
-                                    (asdf:find-component
-                                     :py4cl2 "python-code")))
-                                  " & set PYTHONIOENCODING=OLDPYTHONIOENCODING")
-                     :sharing :lock
-                     :input :stream
-                     :output :stream
-                     :error-output :stream)
-                    #+unix
-                    (uiop:launch-program
-                     (concatenate 'string
-                                  "bash -c \""
-                                  (bash-escape-string command)
-                                  " -u "
-                                  ;; Unbuffered is important if flush=True
-                                  ;; should not be required for asynchronous output.
-                                  ;; TODO: Add test for unflushed async output; been unable to
-                                  ;; The closest thing is the INTERRUPT test.
-                                  "\"' <(cat <<\"EOF\""
-                                  (string #\newline)
-                                  *python-code*
-                                  (string #\newline)
-                                  "EOF"
-                                  (string #\newline)
-                                  ")'\" "
-                                  (bash-escape-string
-                                   (directory-namestring
-                                    (asdf:component-pathname
-                                     (asdf:find-component
-                                      :py4cl2 "python-code"))))
-                                  "\"")
-                     :sharing :lock
-                     :input :stream
-                     :output :stream
-                     :error-output :stream))
-              (sleep 0.1)
-              (unless (python-alive-p)
-                (let ((*python-startup-error* (or (ignore-errors
-                                                   (read-stream-content-into-string
-                                                    (uiop:process-info-error-output *python*)))
-                                                  "Unable to fetch more error details on ECL")))
-                  (cerror "Provide another path (setf (config-var 'pycmd) ...)"
-                          'python-process-startup-error :command command))
-                (format t "~&Provide the path to python binary to use (eg python): ")
-                (let ((cmd (read-line)))
-                  (setf (config-var 'pycmd) cmd)
-                  (setf command cmd)))))
-  (unless *py4cl-tests*
-    (setq *python-output-thread*
-          (bt:make-thread
-           (lambda ()
-             (when *python*
-               (let ((py-out (uiop:process-info-error-output *python*)))
-                 (iter outer
-                   (while (and *python* (python-alive-p *python*)))
-                   (handler-case
-                       (for char =
-                            (progn
-                              ;; PEEK-CHAR waits for input
-                              (peek-char nil py-out nil)
-                              (when *in-with-python-output*
-                                (iter (while *in-with-python-output*)
-                                  (bt:wait-on-semaphore *python-output-semaphore*))
-                                (in outer (next-iteration)))
-                              (read-char py-out nil)))
-                     (simple-error (condition)
-                       (error "~S~%  ~A~%occured while inside *python-output-thread* ~A"
-                              condition condition *python-output-thread*))
-                     (stream-error (condition)
-                       (unless (member :abcl *features*)
-                         (error "~S~%  ~A~%occured while inside *python-output-thread* ~A"
-                                condition condition *python-output-thread*))))
-                   (when char (write-char char)))))))))
-  (cond ((and (numpy-installed-p)
-              (not (member :arrays *internal-features*)))
-         (push :arrays *internal-features*))
-        ((and (not (numpy-installed-p))
-              (member :arrays *internal-features*))
-         (removef *internal-features* :arrays)))
-  (incf *current-python-process-id*)
-  (apply #'raw-pyexec *additional-init-codes*))
+		 (#\' (write-string "\\'" str))
+		 (#\( (write-string "\\(" str))
+		 (#\) (write-string "\\)" str))
+		 (#\space (write-string "\\ " str))
+		 (t (write-char ch str)))))
+      (map nil #'escape-char string))))
+
+(defun try-start-python (command)
+  (let* ((pathname
+	  (asdf:component-pathname
+	   (asdf:find-component
+	    :py4cl2 "python-code")))
+	 (program-name
+          #+(or os-windows windows)
+          (concatenate 'string
+                       "set OLDPYTHONIOENCODING=PYTHONIOENCODING && set PYTHONIOENCODING=utf8 && "
+                       command
+                       " -u "
+		       (namestring pathname)
+                       " "
+		       (directory-namestring pathname)
+                       " & set PYTHONIOENCODING=OLDPYTHONIOENCODING")
+          #+unix
+          (concatenate 'string
+                       "bash -c \""
+                       (bash-escape-string command)
+                       " -u "
+                       ;; Unbuffered is important if flush=True
+                       ;; should not be required for asynchronous output.
+                       ;; TODO: Add test for unflushed async output; been unable to
+                       ;; The closest thing is the INTERRUPT test.
+                       "\"' <(cat <<\"EOF\""
+                       (string #\newline)
+                       *python-code*
+                       (string #\newline)
+                       "EOF"
+                       (string #\newline)
+                       ")'\" "
+                       (bash-escape-string
+                        (directory-namestring
+			 pathname))
+		       "\"")))
+    (uiop:launch-program program-name
+                         :sharing :lock :input :stream :output :stream :error-output :stream)))
+
+(defvar *get-results* 'get-results&)
+
+(defun get-results (python)
+  (funcall *get-results* python))
+  
+(defun interaction-loop
+    (python)
+  "This is the loop that handles all communication back from the
+ python process.  We need to be re-entrant because we may call
+ callbacks from this thread which are allowed to call back into python
+ and can block on get-results.  That includes being able to print
+ python objects.  Re-entrance is handled by having calls into
+ get-result be difference when in this loop.  We need to handle
+ *lispifiers* and *pythonizers*."
+  (let ((*get-results*
+	 (lambda (python)
+	   (dispatch-messages (python-output python) (python-input python))))
+        (*print-python-object* nil)) ;; avoid deadlocks
+    (declare (special *get-results* *print-python-object*))
+    (loop
+       until (or (python-thread-end-signal python) (not (python-alive-p python)))
+       with output-stream = (python-output python)
+       with input-stream = (python-input python)
+       do
+	 (handler-case
+	     (progn
+	       (pp-debug-print "IT: Waiting for python to say something~%")
+	       (peek-char nil output-stream t)
+	       (pp-debug-print "IT: Got something, grabbing interaction lock~%")
+	       (bt:with-recursive-lock-held ((python-interaction-lock python))
+		 (pp-debug-print "IT: got lock, calling dispatch-message~%")
+                 (let ((*holding-interaction-lock-already* t)
+                       (*lispifiers* (python-lispifiers python))
+                       (*pythonizers* (python-pythonizers python)))
+                   (declare (special *holding-interaction-lock-already*
+                                     *lispifiers* *pythonizers*))
+		   (multiple-value-bind (result result-occurred)
+		       (dispatch-messages output-stream input-stream)
+		     (pp-debug-print "IT: result-occurred ~A~%" result-occurred)
+		     (when (or result result-occurred)
+		       (pp-debug-print "IT: Got result ~S~%" result)
+		       (unless (null (python-interaction-results python))
+		         (format *standard-output* "Unexpected results from python!~%")
+		         (map nil (lambda (x)
+				    (if (functionp x) (funcall x) (format *standard-output* "~A~%" x)))
+			      (python-interaction-results python))
+		         (setf (python-interaction-results python) nil))
+		       (push result (python-interaction-results python))
+		       (pp-debug-print "IT: Results is now ~S, notifying waiters~%" (python-interaction-results python))
+		       (bt:condition-notify (python-interaction-wait python)))))))
+	   (end-of-file (condition)
+	     ;; We end up signalling errors from both this thread and the stderr thread
+	     (format *standard-output* "Python #~A STDOUT got ~A~%" (python-id python) condition)
+	     (labels ((signal-error ()
+			(error (if (python-alive-p python)
+			           'python-eof-but-alive
+			           'python-eof-and-dead)
+			       :python-process (python-subprocess python))))
+	       (bt:with-lock-held ((python-interaction-lock python))
+		 (push
+		  #'signal-error
+		  (python-interaction-results python))
+		 (bt:condition-notify (python-interaction-wait python)))))))))
+
+(defparameter *pystart-lock* (bt:make-recursive-lock))
+
+(defun pystart (&optional (command (config-var 'pycmd)) (python *python*))
+  "Start a new python subprocess if PYTHON is not currently alive.  If an
+ existing (and potentially dead) python is passed in, nothing will
+ occur if it is alive, otherwise it will be restarted.  Returns a
+ running python process.  If there is no global *python*, then it will
+ be updated to this running python process.
+
+ COMMAND is a string with the python executable to launch e.g. \"python\"
+ By default this is is set to (CONFIG-VAR 'PYCMD)"
+  (when (python-alive-p python)
+    (format t "Python is already alive~%")
+    (return-from pystart python))
+  (bt:with-recursive-lock-held (*pystart-lock*)
+    (when (python-alive-p python)
+      (format t "Python is already alive~%")
+      (return-from pystart python))
+    (when python
+      (pystop python)
+      (setf (python-subprocess python) nil))
+    (format t "Restarting python process~%")
+    (unless python (setf python (make-python)))
+    (let ((subprocess nil))
+      (setf (python-id python) (incf *python-id*))
+      (loop
+	:until (python-alive-p python)
+	:do (setf subprocess (try-start-python command))
+            (sleep 0.1)
+	    (unless (python-alive-p subprocess)
+              (cerror "Provide another path (setf (config-var 'pycmd) ...)"
+                      'python-process-startup-error :command command
+		      :error-string (or (ignore-errors
+					 (read-stream-content-into-string
+					  (python-error-output subprocess)))
+					"Unable to fetch more error details on ECL"))
+              (format t "~&Provide the path to python binary to use (eg python): ")
+              (let ((cmd (read-line)))
+		(setf (config-var 'pycmd) cmd)
+		(setf command cmd)))
+	    (setf (python-subprocess python) subprocess))
+      (unless (not subprocess)
+	(setf (python-interaction-results python) nil) ;; clear any old stuff if restarting
+	(setf (python-interaction-thread python)
+	      (bt:make-thread
+	       (lambda () (interaction-loop python))
+	       :name "interaction-thread"))
+	(setf (python-output-thread python)
+              (bt:make-thread
+               (lambda ()
+		 (handler-case
+                     (loop
+		       with output-lock = (python-output-lock python)
+		       with py-out = (python-error-output python)
+                       while (and (python-alive-p python) (not (python-thread-end-signal python)))
+		       with last-notified-of-spurious-output = (get-universal-time)
+		       ;; Someone may be waiting to grab with-python-output
+		       do ;; ideally we would not block, but we do
+			  (let ((char (read-char py-out)))
+			    (when char
+			      (if (python-in-with-python-output python)
+				  (progn
+				    (bt:with-lock-held (output-lock)
+				      (assert (< (length (python-output-result python)) 10000000))
+				      (vector-push-extend char (python-output-result python))))
+				  (progn
+				    (when (> (- (get-universal-time) last-notified-of-spurious-output) 1)
+				      (format *standard-output* "Spurious output from python #~A:~%"
+					      (python-id python))
+				      (setf last-notified-of-spurious-output (get-universal-time)))
+				    (write-char char))))))
+                   (simple-error (condition)
+		     (cerror "ACCEPT" "~S~%  ~A~%occured while inside python-output-thread" condition condition))
+		   (end-of-file (condition)
+		     ;; User will get a debugger from the interaction thread, better to only have one
+		     ;; Messages will probably be garbled as we write from two threads, but better than nothing
+		     (format *standard-output*
+			     "Python #~A: EOF on STDERR ~A received ~@[last message was ~A~]~%"
+			     (python-id python)
+			     condition (unless (emptyp (python-output-result python))
+					 (python-output-result python))))
+                   (stream-error (condition)
+                     (unless (member :abcl *features*)
+                       (cerror "ACCEPT" "~S~%  ~A~%occured while inside python-output-thread" condition condition)))))
+	       :name "stderr thread")))
+      (assert (python-alive-p python))
+      (setf (python-numpy-installed python) (numpy-installed-p python))
+      (when (numpy-installed-p python)
+	(pushnew :arrays *internal-features*))
+      (unless *python* (setf *python* python))
+      (apply #'raw-pyexec *additional-init-codes*)
+      python)))
 
 (defmacro with-python-output (&body forms-decl)
-  "Gets the output of the python program executed in FORMS-DECL in the form a string."
-  `(with-output-to-string (output-stream)
+  "Gets the output of the python program executed in FORMS-DECL in the form a string.
+ We need to synchronize ourselves with the python output, there is no way to guarantee
+ timing between flushing and when we get the data, so we need to use a marker in the stream
+ ... we use a random value."
+  `(progn
      (when (and *warn-on-unavailable-feature-usage*
                 (not (member :with-python-output *internal-features*)))
        (warn "WITH-PYTHON-OUTPUT may not work on your system."))
-     (unwind-protect (progn
-                       (setq *in-with-python-output* t)
+     (let ((end-string (format nil "~A" (random (expt 2 61)))))
+       (unwind-protect
+	    (progn
+	      (setf (python-in-with-python-output *python*) t)
                        ,@forms-decl
-                       (sleep 0.00002)
-                       (let ((py-out (uiop:process-info-error-output *python*)))
-                         (iter (while (listen py-out))
-                           (for char = (read-char py-out nil))
-                           (when char (write-char char output-stream)))))
-       (setq *in-with-python-output* nil)
-       (bt:signal-semaphore *python-output-semaphore*))))
+	      (pycall "print" end-string :end "" :flush t)
+	      (loop until (bt:with-lock-held ((python-output-lock *python*))
+			    (string= (python-output-result *python*)
+				     end-string
+				     :start1 (max 0 (- (length (python-output-result *python*))
+						       (length end-string)))
+				     :start2 0))
+		    do (sleep 0.00001))
+	      (decf (fill-pointer (python-output-result *python*)) (length end-string))
+	      (prog1
+		  (copy-seq (python-output-result *python*))
+		(setf (fill-pointer (python-output-result *python*)) 0)))
+	 (setf (python-in-with-python-output *python*) nil)))))
 
-(defun python-alive-p (&optional (process-info *python*))
-  "Returns non-NIL if the python process is alive
-(e.g. SBCL -> T, CCL -> RUNNING).
-Optionally pass the process object returned by PYTHON-START"
-  (and process-info
-       (uiop:process-alive-p process-info)))
-
-(defun python-start-if-not-alive ()
+(defun python-start-if-not-alive (&optional (python *python*))
   "If no python process is running, tries to start it.
 If still not alive, raises a condition."
-  (unless (python-alive-p)
-    (pystart)))
+  (unless (and python (python-alive-p python))
+    (pystart (config-var 'pycmd) python)))
 
-;; Function defined in writer.lisp, which clears an object store
-(declaim (ftype (function () t) clear-lisp-objects))
-
-(defun pystop (&optional (process-info *python*))
+(defun pystop (&optional (python *python*))
   "Stop (Quit) the python process PROCESS"
-  (unless (python-alive-p process-info)
-    (return-from pystop))
-  (let ((stream (uiop:process-info-input process-info)))
-    ;; ask the python process to quit; might require a few sec?
-    (write-char #\q stream))
-  (uiop:terminate-process process-info)
-  (if (bt:thread-alive-p *python-output-thread*) (bt:destroy-thread *python-output-thread*))
-  (setf *python* nil) ;; what about multiple processes?
-  (clear-lisp-objects))
+  (setf (python-thread-end-signal python) t)
+  (when (python-alive-p python)
+    (sleep 0.01) ;; wait for threads to die
+    (write-char #\q (python-input python)) ;; can't be sure they aren't still waiting for output
+    (finish-output (python-input python))
+    (loop repeat 1000
+	  until (not (python-alive-p python)))
+    (sleep 0.01)) ;; wait for python to die before axing it
+  (when (python-alive-p python)
+    (ignore-errors (uiop:terminate-process (subprocess python)))
+    (ignore-errors (uiop:terminate-process (subprocess python) :urgent t)))
+  ;; We no longer care about any objects that needed to be freed in python
+  (setf (python-freed-python-objects python) nil)
+  (delete-numpy-pickle-arrays python)
+  (if (bt:thread-alive-p (python-output-thread python)) (bt:destroy-thread (python-output-thread python)))
+  (if (bt:thread-alive-p (python-interaction-thread python)) (bt:destroy-thread (python-interaction-thread python)))
+  (setf (python-thread-end-signal python) nil)
+  (clear-lisp-objects python)
+  (setf (fill-pointer (python-output-result python)) 0)
+  (setf (python-interaction-results python) nil)
+  (setf (python-output-lock python) (bt:make-recursive-lock))
+  (setf (python-interaction-lock python) (bt:make-recursive-lock))
+  (setf (python-raw-py-lock python) (bt:make-recursive-lock))
+  (setf (python-interaction-wait python) (bt:make-condition-variable :name "stdin stream waitqueue"))
+  (setf (python-subprocess python) nil))
 
-(defun pyinterrupt (&optional (process-info *python*))
+(defun pyinterrupt (&optional (python *python*))
   "Issues a SIGINT command to the python process"
   (when (and *warn-on-unavailable-feature-usage*
              (not (member :with-python-output *internal-features*)))
     (warn "Might not be able to issue a SIGINT to the python process on your system."))
-  (when (and (python-alive-p process-info)
-             *python-process-busy-p*)
+  ;; Interrupt and grab any results
+  (when (python-alive-p python)
     (uiop:run-program
-     (concatenate 'string "/bin/kill -SIGINT -"
-                  (write-to-string (uiop:process-info-pid process-info)))
-     :force-shell t)
-    (setq *python-process-busy-p* nil)
-    ;; something to do with running in separate threads! "deftest interrupt"
-    (unless *py4cl-tests* (dispatch-messages process-info))))
+     (concatenate 'string "/bin/kill -SIGINT "
+                  (write-to-string (uiop:process-info-pid (subprocess python))))
+     :force-shell t)))

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -36,6 +36,9 @@
   (id (incf *python-id*) :type fixnum) ;; unique id
   (freed-python-objects nil :type list) ;; lisp objects that have been gc'ed, free them from python
   (numpy-pickle-index 0 :type fixnum)
+  ;; "Used for transferring multiple numpy-pickled arrays in one pyeval/exec/etc")
+  ;; this is incremented by pythonize and reset to 0 at the beginning of
+  ;; every pyeval*/pycall from delete-numpy-pickle-arrays in reader.lisp
   (lisp-objects nil :type list) ;; lisp objects that python might know about
   (numpy-installed nil :type boolean)
   (thread-end-signal nil :type boolean) ;; t to gently stop threads

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -393,8 +393,8 @@ If still not alive, raises a condition."
   (setf (python-thread-end-signal python) t)
   (when (python-alive-p python)
     (sleep 0.01) ;; wait for threads to die
-    (write-char #\q (python-input python)) ;; can't be sure they aren't still waiting for output
-    (finish-output (python-input python))
+    (ignore-errors (write-char #\q (python-input python))) ;; can't be sure they aren't still waiting for output
+    (ignore-errors (finish-output (python-input python)))
     (loop repeat 1000
 	  until (not (python-alive-p python)))
     (sleep 0.01)) ;; wait for python to die before axing it

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -239,6 +239,11 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
 
 (defvar *request-id* (list 0))
 
+(defstruct python-message
+  (cmd-char #\! :type character)
+  (string "" :type string)
+  (response-id -1 :type fixnum))
+
 (defun make-request (python cmd-char request-string)
   ;; For use by Lisp client threads to call into Python
   ;; Outer lock keeps out other lisp clients
@@ -306,7 +311,7 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
     do
        (bt:with-recursive-lock-held ((python-interaction-lock python))
          (let ((p (peek (python-read-queue python))))
-           (when (and p (eql (python-message-cmd-char p) #\c))
+           (when (and p (member (python-message-cmd-char p) '(#\c #\d)))
              ;;(notify-user "async callback processing ~A" p) 
              (let ((raw-response (read-from-python-queue python)))
                (multiple-value-bind (response response-returned)
@@ -322,11 +327,6 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
                                (error "Unexpected response ~A" response)
                              (ignore ()))))))))))
        (sleep 0.05)))
-
-(defstruct python-message
-  (cmd-char #\! :type character)
-  (string "" :type string)
-  (response-id -1 :type fixnum))
 
 (defparameter *pystart-lock* (bt:make-recursive-lock))
 

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -88,7 +88,7 @@
   (in-with-python-output nil :type boolean)
   (id (incf *python-id*) :type fixnum) ;; unique id
   (freed-python-objects nil :type list) ;; lisp objects that have been gc'ed, free them from python
-  (numpy-pickle-index 0 :type fixnum)
+  (numpy-pickle-index 0 :type (unsigned-byte 64))
   ;; "Used for transferring multiple numpy-pickled arrays in one pyeval/exec/etc")
   ;; this is incremented by pythonize and reset to 0 at the beginning of
   (lisp-objects nil :type list) ;; lisp objects that python might know about

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -209,8 +209,8 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
                  (with-sldb-default-restart ignore
 		   (restart-case
 		       (funcall (python-error-thunk result))
-		     (ignore ()))
-		   result)))))
+		     (ignore ())))
+		 result))))
         (*print-python-object* nil)) ;; avoid deadlocks
     (declare (special *get-results* *print-python-object*))
     (loop
@@ -259,6 +259,8 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
 		 (bt:condition-notify (python-interaction-wait python)))))))))
 
 (defparameter *pystart-lock* (bt:make-recursive-lock))
+
+(defparameter *spurious-info* (make-array 0 :fill-pointer t :element-type 'base-char))
 
 (defun pystart (&optional (command (config-var 'pycmd)) (python *python*))
   "Start a new python subprocess if PYTHON is not currently alive.  If an
@@ -328,6 +330,7 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
 				      (format *standard-output* "Spurious output from python #~A:~%"
 					      (python-id python))
 				      (setf last-notified-of-spurious-output (get-universal-time)))
+                                    (vector-push-extend char *spurious-info*)
 				    (write-char char))))))
                    (simple-error (condition)
 		     (cerror "ACCEPT" "~S~%  ~A~%occured while inside python-output-thread" condition condition))

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -13,6 +13,61 @@
 ;; stderr is what python thinks stdout is, so on that we capture
 ;; printed output and misc error output.
 
+;; Request / return-value pairs occur in a stack like format, the most
+;; response return-value response from python is always associated with
+;; the most recently sent request.  We use python-interactions as the
+;; equivalent stack to keep request/return-value responses in order.
+;; That doesn't work either because python may get an EVAL request, be
+;; working on it, the interaction thread goes to sleep as does the caller
+;; and another thread comes in and asks for a request, thus getting
+;; matched.
+
+(defstruct queue-elt
+  (elt nil)
+  (next nil :type (or null queue-elt))
+  (previous nil :type (or null queue-elt)))
+
+(defstruct queue
+  (head nil :type (or null queue-elt))
+  (tail nil :type (or null queue-elt))
+  (waitqueue (bt:make-condition-variable))
+  (lock (bt:make-lock)))
+
+(defun enqueue (queue elt)
+  "push to tail"
+  (bt:with-lock-held ((queue-lock queue))
+    (let* ((tail (queue-tail queue))
+           (new-queue-elt (make-queue-elt :elt elt :next nil :previous tail)))
+      (when (not (queue-head queue)) (setf (queue-head queue) new-queue-elt))
+      (when tail
+        (setf (queue-elt-next (queue-tail queue)) new-queue-elt))
+      (setf (queue-tail queue) new-queue-elt)
+      (bt2:condition-broadcast (queue-waitqueue queue)))))
+
+(defun dequeue (queue)
+  "pop from head"
+  (bt:with-lock-held ((queue-lock queue))
+    (let ((elt (queue-head queue)))
+      (cond
+        (elt
+         (let ((next (queue-elt-next elt)))
+           (setf (queue-head queue) next)
+           (if (eq elt (queue-tail queue))
+               (setf (queue-tail queue) nil)
+               (setf (queue-elt-previous next) nil)))
+         (values (queue-elt-elt elt) t))
+        (t (values nil nil))))))
+
+(defun wait (queue)
+  (bt:with-lock-held ((queue-lock queue))
+    (unless (queue-head queue)
+      (bt:condition-wait (queue-waitqueue queue) (queue-lock queue)))))
+
+(defun peek (queue)
+  (bt:with-lock-held ((queue-lock queue))
+    (let ((elt (queue-head queue)))
+      (when elt
+        (values (queue-elt-elt elt) t)))))
 
 (defstruct python
   (subprocess nil)
@@ -21,17 +76,10 @@
   (output-thread nil :type (or null bt:thread))
   ;; gets written to when in #'with-python-output
   (output-result (make-array 0 :element-type 'character :adjustable t :fill-pointer t) :type vector)
-  ;; This lock deals with reading data back from python
-  (interaction-thread nil :type (or null bt:thread))
-  (interaction-lock (bt:make-recursive-lock) :type bt:lock)
-  (interaction-wait (bt:make-condition-variable :name "stdin stream waitqueue"))
-  (interaction-results nil :type list) ;; for simplicity we lock
-  ;; This is the user facing lock through raw-py.  Having two locks is dangerous
-  ;; one must make sure the interaction-thread NEVER grabs the raw-py lock
-  ;; as the order of locks is RAW-PY then INTERACTION-LOCK.  While the interaction-thread
-  ;; grabs the INTERACTION-LOCK without the RAW-PY lock.  This is the PYTHON-DURING-CALLBACK
-  ;; test
-  (raw-py-lock (bt:make-recursive-lock) :type bt:lock)
+  (interaction-lock (bt:make-recursive-lock "interaction-lock") :type bt:lock) ;; single threads lisp clients
+  (async-callback-thread nil :type (or null bt:thread))
+  (read-thread nil :type (or null bt:thread))
+  (read-queue (make-queue) :type queue)
   (in-with-python-output nil :type boolean)
   (id (incf *python-id*) :type fixnum) ;; unique id
   (freed-python-objects nil :type list) ;; lisp objects that have been gc'ed, free them from python
@@ -41,9 +89,9 @@
   ;; every pyeval*/pycall from delete-numpy-pickle-arrays in reader.lisp
   (lisp-objects nil :type list) ;; lisp objects that python might know about
   (numpy-installed nil :type boolean)
-  (thread-end-signal nil :type boolean) ;; t to gently stop threads
-  (lispifiers nil :type list)
-  (pythonizers nil :type list))
+  (thread-end-signal nil :type boolean)  ;; t to gently stop threads
+  (lispifiers *lispifiers*)
+  (pythonizers *pythonizers*))
 
 (defun subprocess (python/subprocess)
   (if (python-p python/subprocess)
@@ -76,52 +124,21 @@
 
 (defmacro pp-debug-print (&rest rest)
   (declare (ignorable rest))
-  #+debug `(format *standard-output* ,@rest))
-
-(defun get-results& (python)
-  "Block until some results from python.  But cannot block if the
- interaction thread is calling us."
-  (declare (optimize speed safety))
-  (let ((lock (python-interaction-lock python)))
-    (pp-debug-print "GR: Grabbing interaction lock~%")
-    (bt:with-recursive-lock-held (lock)
-      (pp-debug-print "GR: Got interaction lock~%")
-      (loop
-	for is-result = (python-interaction-results python)
-	for result = (pop (python-interaction-results python))
-	until is-result ;; result may be nil!
-	do
-	   (pp-debug-print "GR: waiting on interaction-wait~%")
-           ;; Here we have a race, because we want to give control
-           ;; back to the interaction thread, but someone else may
-           ;; be in raw-py waiting to grab the interaction lock and
-           ;; if they get it, they will get our results.  But this
-           ;; is prevented by the raw-py lock.
-	   (unless (python-alive-p python)
-	     (error 'python-eof-and-dead :python-process (python-subprocess python) :stream nil))
-	   (bt:condition-wait (python-interaction-wait python) lock :timeout 1)
-	finally
-	   (pp-debug-print "GR: Got result ~S~%" result)
-           ;; It's a delayed error
-           (when (python-error-p result)
-             (funcall (python-error-thunk result)))
-           (when (python-interaction-results python)
-             (error (format nil "More results than expected: ~A" (pop (python-interaction-results python)))))
-	   (return result)))))
+  #+debug `(notify-user ,@rest))
 
 (declaim (type (or null python) *python*))
-(defvar *python* nil "Current `python' instance")
+
 (defvar *py4cl-tests* nil "Not needed, but here for backwards compatibility")
   ;; We are loading the whole file into a variable, because we want users to be able
   ;; to use py4cl2 even in a dumped lisp image, without any additional configuration.
-  (defvar *python-code*
-    (alexandria:read-file-into-string
-     (asdf:component-pathname
-      (asdf:find-component :py4cl2 "python-code"))))
+(defparameter *python-code*
+  (alexandria:read-file-into-string
+   (asdf:component-pathname
+    (asdf:find-component :py4cl2 "python-code"))))
 
-  (declaim (type list *additional-init-codes*))
-  (defvar *additional-init-codes* nil
-    "A list of strings each of which should be python code. All the code
+(declaim (type list *additional-init-codes*))
+(defvar *additional-init-codes* nil
+  "A list of strings each of which should be python code. All the code
 will be executed by PYSTART. The code should not contain single-quotation marks.")
 
 (define-condition python-process-startup-error (error)
@@ -174,7 +191,9 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
                        ;; The closest thing is the INTERRUPT test.
                        "\"' <(cat <<\"EOF\""
                        (string #\newline)
-                       *python-code*
+                       *python-code*;; (alexandria:read-file-into-string
+                       ;;  (asdf:component-pathname
+                       ;;   (asdf:find-component :py4cl2 "python-code")))
                        (string #\newline)
                        "EOF"
                        (string #\newline)
@@ -195,71 +214,119 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
   `(let (#+swank (swank:*sldb-quit-restart* ',restart-name))
      ,@body))
 
-(defun interaction-loop
-    (python)
-  "This is the loop that handles all communication back from the
- python process.  We need to be re-entrant because we may call
- callbacks from this thread which are allowed to call back into python
- and can block on get-results.  That includes being able to print
- python objects.  Re-entrance is handled by having calls into
- get-result be difference when in this loop.  We need to handle
- *lispifiers* and *pythonizers*."
-  (let ((*get-results*
-	 (lambda (python)
-	   (let ((result (dispatch-messages (python-output python) (python-input python))))
-	     (if (python-error-p result)
-	       ;; Handle errors
-                 (with-sldb-default-restart ignore
-		   (restart-case
-		       (funcall (python-error-thunk result))
-		     (ignore ())))
-		 result))))
-        (*print-python-object* nil)) ;; avoid deadlocks
-    (declare (special *get-results* *print-python-object*))
-    (loop
-       until (or (python-thread-end-signal python) (not (python-alive-p python)))
-       with output-stream = (python-output python)
-       with input-stream = (python-input python)
-       do
-	 (handler-case
-	     (progn
-	       (pp-debug-print "IT: Waiting for python to say something~%")
-	       (peek-char nil output-stream t)
-	       (pp-debug-print "IT: Got something, grabbing interaction lock~%")
-	       (bt:with-recursive-lock-held ((python-interaction-lock python))
-		 (pp-debug-print "IT: got lock, calling dispatch-message~%")
-                 (let ((*holding-interaction-lock-already* t)
-                       (*lispifiers* (python-lispifiers python))
-                       (*pythonizers* (python-pythonizers python)))
-                   (declare (special *holding-interaction-lock-already*
-                                     *lispifiers* *pythonizers*))
-		   (multiple-value-bind (result result-occurred)
-		       (dispatch-messages output-stream input-stream)
-		     (pp-debug-print "IT: result-occurred ~A~%" result-occurred)
-		     (when (or result result-occurred)
-		       (pp-debug-print "IT: Got result ~S~%" result)
-		       (unless (null (python-interaction-results python))
-		         (format *standard-output* "Unexpected results from python!~%")
-		         (map nil (lambda (x)
-				    (if (functionp x) (funcall x) (format *standard-output* "~A~%" x)))
-			      (python-interaction-results python))
-		         (setf (python-interaction-results python) nil))
-		       (push result (python-interaction-results python))
-		       (pp-debug-print "IT: Results is now ~S, notifying waiters~%" (python-interaction-results python))
-		       (bt:condition-notify (python-interaction-wait python)))))))
-	   (end-of-file (condition)
-	     ;; We end up signalling errors from both this thread and the stderr thread
-	     (format *standard-output* "Python #~A STDOUT got ~A~%" (python-id python) condition)
-	     (labels ((signal-error ()
-			(error (if (python-alive-p python)
-			           'python-eof-but-alive
-			           'python-eof-and-dead)
-			       :python-process (python-subprocess python))))
-	       (bt:with-lock-held ((python-interaction-lock python))
-		 (push
-		  #'signal-error
-		  (python-interaction-results python))
-		 (bt:condition-notify (python-interaction-wait python)))))))))
+(declaim (inline make-response-request))
+(defstruct response-request
+  "A box for the response, and any temporary lispifiers and pythonizers to use
+ during the context of the request/response"
+  (response 'NOT-SATISFIED))
+
+(defstruct write-request
+  (cmd-char #\! :type character)
+  (string "" :type string))
+
+(defun is-valid (response)
+  (not (eq (response-request-response response) 'NOT-SATISFIED)))
+
+(defvar *am-read-thread* nil)
+
+(defun read-from-python-queue (python)
+  (let ((r (dequeue (python-read-queue python))))
+    (if (python-error-p r)
+        (restart-case
+            (funcall (python-error-thunk r))
+          (ignore () nil))
+        r)))
+
+(defvar *request-id* (list 0))
+
+(defun make-request (python cmd-char request-string)
+  ;; For use by Lisp client threads to call into Python
+  ;; Outer lock keeps out other lisp clients
+  (bt:with-recursive-lock-held ((python-interaction-lock python))
+    (let ((stream (python-input python))
+          (request-id (when (eql cmd-char #\e) (sb-ext:atomic-incf (car *request-id*)))))
+      (write-char cmd-char stream)
+      (when (eql cmd-char #\e)
+        (write-string (format nil "~A~%" request-id) stream))
+      (stream-write-string request-string stream)
+      (force-output stream)
+      ;; (notify-user "Requested ~A ID:~A ~A" cmd-char request-id request-string)
+      ;; We will process everything, including random callbacks
+      ;; until we get an answer to our request.  dispatch may
+      ;; recurse inside of itself and end up calling make-request,
+      ;; thus the need for a recursive-lock
+      (loop
+        with response = nil
+        for raw-response = (read-from-python-queue python)
+        do (when raw-response
+             (if (or (not request-id)
+                     (= (python-message-response-id raw-response) -1)
+                     (= (python-message-response-id raw-response) request-id))
+                 (multiple-value-bind (response response-returned)
+                     (dispatch python raw-response)
+                   (when (functionp response)
+                     (funcall response))
+                   (when response-returned
+                     (return-from make-request response)))
+                 (progn
+                   ;; a response from some other request
+                   ;; don't busy wait
+                   (enqueue (python-read-queue python) raw-response)
+                   (sleep 0.001))))))))
+
+(defun notify-user (format-string &rest format-args)
+  (apply 'format *standard-output* format-string format-args))
+
+(defun read-loop (python)
+  "Read messages from python, push them to read-queue"
+  (loop
+    with stream = (python-output python)
+    with queue = (python-read-queue python)
+    until (or (python-thread-end-signal python) (not (python-alive-p python)))
+    :for message-char := (read-char stream)
+    :do
+       (case message-char
+         ((#\e #\r)
+          (let ((response-id (parse-integer (read-line stream))))
+            (let ((msg (make-python-message :cmd-char message-char :string (stream-read-string stream)
+                                           :response-id response-id)))
+              ;;(notify-user "Got ~A" msg)
+              (enqueue queue msg))))
+         ((#\d #\s #\S #\c #\p)
+          (let ((msg (make-python-message :cmd-char message-char :string (stream-read-string stream))))
+            ;;(notify-user "Got ~A" msg)
+            (enqueue queue msg)))
+         (otherwise
+          (enqueue queue (make-python-error :thunk (lambda () (error "Unhandled message type '~d'" message-char))))))))
+
+(defun async-callback-loop (python)
+  "Our job is to wait and see if there are answers"
+  (loop
+    until (or (python-thread-end-signal python) (not (python-alive-p python)))
+    do
+       (bt:with-recursive-lock-held ((python-interaction-lock python))
+         (let ((p (peek (python-read-queue python))))
+           (when (and p (eql (python-message-cmd-char p) #\c))
+             ;;(notify-user "async callback processing ~A" p) 
+             (let ((raw-response (read-from-python-queue python)))
+               (multiple-value-bind (response response-returned)
+                   (dispatch python raw-response)
+                 (when response-returned
+                   (if (python-error-p response)
+                       (restart-case
+                           (funcall (python-error-thunk response))
+                         (ignore ()))
+                       (if (functionp response)
+                           (funcall response)
+                           (restart-case
+                               (error "Unexpected response ~A" response)
+                             (ignore ()))))))))))
+       (sleep 0.05)))
+
+(defstruct python-message
+  (cmd-char #\! :type character)
+  (string "" :type string)
+  (response-id -1 :type fixnum))
 
 (defparameter *pystart-lock* (bt:make-recursive-lock))
 
@@ -305,11 +372,14 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
 		(setf command cmd)))
 	    (setf (python-subprocess python) subprocess))
       (unless (not subprocess)
-	(setf (python-interaction-results python) nil) ;; clear any old stuff if restarting
-	(setf (python-interaction-thread python)
+	(setf (python-read-thread python)
 	      (bt:make-thread
-	       (lambda () (interaction-loop python))
-	       :name "interaction-thread"))
+	       (lambda () (read-loop python))
+	       :name "reader-thread"))
+        (setf (python-async-callback-thread python)
+	      (bt:make-thread
+	       (lambda () (async-callback-loop python))
+	       :name "async-callback-loop"))
 	(setf (python-output-thread python)
               (bt:make-thread
                (lambda ()
@@ -330,8 +400,7 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
 				      (vector-push-extend char (python-output-result python))))
 				  (progn
 				    (when (> (- (get-universal-time) last-notified-of-spurious-output) 1)
-				      (format *standard-output* "Spurious output from python #~A:~%"
-					      (python-id python))
+				      (notify-user "Spurious output from python #~A:~%" (python-id python))
 				      (setf last-notified-of-spurious-output (get-universal-time)))
                                     (vector-push-extend char *spurious-info*)
 				    (write-char char))))))
@@ -340,7 +409,7 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
 		   (end-of-file (condition)
 		     ;; User will get a debugger from the interaction thread, better to only have one
 		     ;; Messages will probably be garbled as we write from two threads, but better than nothing
-		     (format *standard-output*
+		     (notify-user
 			     "Python #~A: EOF on STDERR ~A received ~@[last message was ~A~]~%"
 			     (python-id python)
 			     condition (unless (emptyp (python-output-result python))
@@ -393,31 +462,32 @@ If still not alive, raises a condition."
 
 (defun pystop (&optional (python *python*))
   "Stop (Quit) the python process PROCESS"
-  (setf (python-thread-end-signal python) t)
-  (when (python-alive-p python)
-    (sleep 0.01) ;; wait for threads to die
-    (ignore-errors (write-char #\q (python-input python))) ;; can't be sure they aren't still waiting for output
-    (ignore-errors (finish-output (python-input python)))
-    (loop repeat 1000
-	  until (not (python-alive-p python)))
-    (sleep 0.01)) ;; wait for python to die before axing it
-  (when (python-alive-p python)
-    (ignore-errors (uiop:terminate-process (subprocess python)))
-    (ignore-errors (uiop:terminate-process (subprocess python) :urgent t)))
-  ;; We no longer care about any objects that needed to be freed in python
-  (setf (python-freed-python-objects python) nil)
-  (delete-numpy-pickle-arrays python)
-  (if (bt:thread-alive-p (python-output-thread python)) (bt:destroy-thread (python-output-thread python)))
-  (if (bt:thread-alive-p (python-interaction-thread python)) (bt:destroy-thread (python-interaction-thread python)))
-  (setf (python-thread-end-signal python) nil)
-  (clear-lisp-objects python)
-  (setf (fill-pointer (python-output-result python)) 0)
-  (setf (python-interaction-results python) nil)
-  (setf (python-output-lock python) (bt:make-recursive-lock))
-  (setf (python-interaction-lock python) (bt:make-recursive-lock))
-  (setf (python-raw-py-lock python) (bt:make-recursive-lock))
-  (setf (python-interaction-wait python) (bt:make-condition-variable :name "stdin stream waitqueue"))
-  (setf (python-subprocess python) nil))
+  (when python
+    (setf (python-thread-end-signal python) t)
+    (when (python-alive-p python)
+      (sleep 0.01)                                         ;; wait for threads to die
+      (ignore-errors (write-char #\q (python-input python))) ;; can't be sure they aren't still waiting for output
+      (ignore-errors (finish-output (python-input python)))
+      (loop repeat 1000
+	    until (not (python-alive-p python)))
+      (sleep 0.01)) ;; wait for python to die before axing it
+    (when (python-alive-p python)
+      (ignore-errors (uiop:terminate-process (subprocess python)))
+      (ignore-errors (uiop:terminate-process (subprocess python) :urgent t)))
+    ;; We no longer care about any objects that needed to be freed in python
+    (setf (python-freed-python-objects python) nil)
+    (delete-numpy-pickle-arrays python)
+    (if (bt:thread-alive-p (python-output-thread python)) (bt:destroy-thread (python-output-thread python)))
+    (if (bt:thread-alive-p (python-read-thread python)) (bt:destroy-thread (python-read-thread python)))
+    (if (bt:thread-alive-p (python-async-callback-thread python))
+        (bt:destroy-thread (python-async-callback-thread python)))
+    (setf (python-thread-end-signal python) nil)
+    (clear-lisp-objects python)
+    (setf (fill-pointer (python-output-result python)) 0)
+    (setf (python-read-queue python) (make-queue))
+    (setf (python-output-lock python) (bt:make-recursive-lock))
+    (setf (python-interaction-lock python) (bt:make-lock))
+    (setf (python-subprocess python) nil)))
 
 (defun pyinterrupt (&optional (python *python*))
   "Issues a SIGINT command to the python process"

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -71,6 +71,9 @@
  or a python-subprocess thereof"
   (and python (subprocess python) (uiop:process-alive-p (subprocess python))))
 
+(defstruct python-error
+  thunk)
+
 (defmacro pp-debug-print (&rest rest)
   (declare (ignorable rest))
   #+debug `(format *standard-output* ,@rest))

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -187,7 +187,11 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
 
 (defun get-results (python)
   (funcall *get-results* python))
-  
+
+(defmacro with-sldb-default-restart (restart-name &body body)
+  `(let (#+swank (swank:*sldb-quit-restart* ',restart-name))
+     ,@body))
+
 (defun interaction-loop
     (python)
   "This is the loop that handles all communication back from the
@@ -202,10 +206,11 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
 	   (let ((result (dispatch-messages (python-output python) (python-input python))))
 	     (if (python-error-p result)
 	       ;; Handle errors
-		 (restart-case
-		     (funcall (python-error-thunk result))
-		   (ignore ()))
-		 result))))
+                 (with-sldb-default-restart ignore
+		   (restart-case
+		       (funcall (python-error-thunk result))
+		     (ignore ()))
+		   result)))))
         (*print-python-object* nil)) ;; avoid deadlocks
     (declare (special *get-results* *print-python-object*))
     (loop

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -100,8 +100,8 @@
 	finally
 	   (pp-debug-print "GR: Got result ~S~%" result)
            ;; It's a delayed error
-           (when (functionp result)
-             (funcall result))
+           (when (python-error-p result)
+             (funcall (python-error-thunk result)))
            (when (python-interaction-results python)
              (error (format nil "More results than expected: ~A" (pop (python-interaction-results python)))))
 	   (return result)))))
@@ -199,7 +199,13 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
  *lispifiers* and *pythonizers*."
   (let ((*get-results*
 	 (lambda (python)
-	   (dispatch-messages (python-output python) (python-input python))))
+	   (let ((result (dispatch-messages (python-output python) (python-input python))))
+	     (if (python-error-p result)
+	       ;; Handle errors
+		 (restart-case
+		     (funcall (python-error-thunk result))
+		   (ignore ()))
+		 result))))
         (*print-python-object* nil)) ;; avoid deadlocks
     (declare (special *get-results* *print-python-object*))
     (loop

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -64,10 +64,15 @@
       (bt:condition-wait (queue-waitqueue queue) (queue-lock queue)))))
 
 (defun peek (queue)
-  (bt:with-lock-held ((queue-lock queue))
-    (let ((elt (queue-head queue)))
-      (when elt
-        (values (queue-elt-elt elt) t)))))
+  (let ((lock (queue-lock queue)))
+    (bt:with-lock-held (lock)
+      (tagbody
+       :try
+         (let ((elt (queue-head queue)))
+           (when elt
+             (return-from peek (values (queue-elt-elt elt) t)))
+           (bt:condition-wait (queue-waitqueue queue) lock)
+           (go :try))))))
 
 (defstruct python
   (subprocess nil)
@@ -309,24 +314,24 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
   (loop
     until (or (python-thread-end-signal python) (not (python-alive-p python)))
     do
-       (bt:with-recursive-lock-held ((python-interaction-lock python))
-         (let ((p (peek (python-read-queue python))))
-           (when (and p (member (python-message-cmd-char p) '(#\c #\d)))
-             ;;(notify-user "async callback processing ~A" p) 
+       (let ((p (peek (python-read-queue python))))
+         (when (and p (member (python-message-cmd-char p) '(#\c #\d)))
+           (bt:with-recursive-lock-held ((python-interaction-lock python))
+             ;;(notify-user "async callback processing ~A" p)
              (let ((raw-response (read-from-python-queue python)))
-               (multiple-value-bind (response response-returned)
-                   (dispatch python raw-response)
-                 (when response-returned
-                   (if (python-error-p response)
-                       (restart-case
-                           (funcall (python-error-thunk response))
-                         (ignore ()))
-                       (if (functionp response)
-                           (funcall response)
-                           (restart-case
-                               (error "Unexpected response ~A" response)
-                             (ignore ()))))))))))
-       (sleep 0.05)))
+               (when raw-response
+                 (multiple-value-bind (response response-returned)
+                     (dispatch python raw-response)
+                   (when response-returned
+                     (if (python-error-p response)
+                         (restart-case
+                             (funcall (python-error-thunk response))
+                           (ignore ()))
+                         (if (functionp response)
+                             (funcall response)
+                             (restart-case
+                                 (error "Unexpected response ~A" response)
+                               (ignore ())))))))))))))
 
 (defparameter *pystart-lock* (bt:make-recursive-lock))
 

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -91,7 +91,6 @@
   (numpy-pickle-index 0 :type fixnum)
   ;; "Used for transferring multiple numpy-pickled arrays in one pyeval/exec/etc")
   ;; this is incremented by pythonize and reset to 0 at the beginning of
-  ;; every pyeval*/pycall from delete-numpy-pickle-arrays in reader.lisp
   (lisp-objects nil :type list) ;; lisp objects that python might know about
   (numpy-installed nil :type boolean)
   (thread-end-signal nil :type boolean)  ;; t to gently stop threads
@@ -481,7 +480,6 @@ If still not alive, raises a condition."
       (ignore-errors (uiop:terminate-process (subprocess python) :urgent t)))
     ;; We no longer care about any objects that needed to be freed in python
     (setf (python-freed-python-objects python) nil)
-    (delete-numpy-pickle-arrays python)
     (if (bt:thread-alive-p (python-output-thread python)) (bt:destroy-thread (python-output-thread python)))
     (if (bt:thread-alive-p (python-read-thread python)) (bt:destroy-thread (python-read-thread python)))
     (if (bt:thread-alive-p (python-async-callback-thread python))

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -293,25 +293,29 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
 
 (defun read-loop (python)
   "Read messages from python, push them to read-queue"
-  (loop
-    with stream = (python-output python)
-    with queue = (python-read-queue python)
-    until (or (python-thread-end-signal python) (not (python-alive-p python)))
-    :for message-char := (read-char stream)
-    :do
-       (case message-char
-         ((#\e #\r)
-          (let ((response-id (parse-integer (read-line stream))))
-            (let ((msg (make-python-message :cmd-char message-char :string (stream-read-string stream)
-                                           :response-id response-id)))
-              ;;(notify-user "Got ~A" msg)
-              (enqueue queue msg))))
-         ((#\d #\s #\S #\c #\p)
-          (let ((msg (make-python-message :cmd-char message-char :string (stream-read-string stream))))
-            ;;(notify-user "Got ~A" msg)
-            (enqueue queue msg)))
-         (otherwise
-          (enqueue queue (make-python-error :thunk (lambda () (error "Unhandled message type '~d'" message-char))))))))
+  (handler-case
+      (loop
+        with stream = (python-output python)
+        with queue = (python-read-queue python)
+        until (or (python-thread-end-signal python) (not (python-alive-p python)))
+        :for message-char := (read-char stream :eof-error-p t)
+        :do
+           (case message-char
+             ((#\e #\r)
+              (let ((response-id (parse-integer (read-line stream))))
+                (let ((msg (make-python-message :cmd-char message-char :string (stream-read-string stream)
+                                                :response-id response-id)))
+                  ;;(notify-user "Got ~A" msg)
+                  (enqueue queue msg))))
+             ((#\d #\s #\S #\c #\p)
+              (let ((msg (make-python-message :cmd-char message-char :string (stream-read-string stream))))
+                ;;(notify-user "Got ~A" msg)
+                (enqueue queue msg)))
+             (otherwise
+              (enqueue queue (make-python-error :thunk (lambda () (error "Unhandled message type '~d'" message-char)))))))
+    (end-of-file ()
+      (notify-user "EOF reading from python")
+      (enqueue (python-read-queue python) (make-python-error :thunk (lambda () (error 'python-eof-and-dead :python-process python)))))))
 
 (defun async-callback-loop (python)
   "Our job is to wait and see if there are answers"

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -323,7 +323,7 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
     until (or (python-thread-end-signal python) (not (python-alive-p python)))
     do
        (let ((p (peek (python-read-queue python))))
-         (when (and p (member (python-message-cmd-char p) '(#\c #\d)))
+         (when (and p (not (python-error-p p)) (member (python-message-cmd-char p) '(#\c #\d)))
            (bt:with-recursive-lock-held ((python-interaction-lock python))
              ;;(notify-user "async callback processing ~A" p)
              (let ((raw-response (read-from-python-queue python)))

--- a/src/python-process.lisp
+++ b/src/python-process.lisp
@@ -283,8 +283,13 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
                    (enqueue (python-read-queue python) raw-response)
                    (sleep 0.001))))))))
 
+(defvar *notify-user* (lambda (&rest rest)
+                        (apply 'format *standard-output* rest)))
+
 (defun notify-user (format-string &rest format-args)
-  (apply 'format *standard-output* format-string format-args))
+  "Because some of these calls come from threads, you might want to plug this into
+ a logging infrastructure since they won't show up in the slime REPL by default."
+  (apply *notify-user* format-string format-args))
 
 (defun read-loop (python)
   "Read messages from python, push them to read-queue"
@@ -379,7 +384,7 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
 	(setf (python-read-thread python)
 	      (bt:make-thread
 	       (lambda () (read-loop python))
-	       :name "reader-thread"))
+	       :name "python reader-thread"))
         (setf (python-async-callback-thread python)
 	      (bt:make-thread
 	       (lambda () (async-callback-loop python))
@@ -387,7 +392,6 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
 	(setf (python-output-thread python)
               (bt:make-thread
                (lambda ()
-		 (handler-case
                      (loop
 		       with output-lock = (python-output-lock python)
 		       with py-out = (python-error-output python)
@@ -395,32 +399,35 @@ will be executed by PYSTART. The code should not contain single-quotation marks.
 		       with last-notified-of-spurious-output = (get-universal-time)
 		       ;; Someone may be waiting to grab with-python-output
 		       do ;; ideally we would not block, but we do
-			  (let ((char (read-char py-out)))
-			    (when char
-			      (if (python-in-with-python-output python)
-				  (progn
-				    (bt:with-lock-held (output-lock)
-				      (assert (< (length (python-output-result python)) 10000000))
-				      (vector-push-extend char (python-output-result python))))
-				  (progn
-				    (when (> (- (get-universal-time) last-notified-of-spurious-output) 1)
-				      (notify-user "Spurious output from python #~A:~%" (python-id python))
-				      (setf last-notified-of-spurious-output (get-universal-time)))
-                                    (vector-push-extend char *spurious-info*)
-				    (write-char char))))))
-                   (simple-error (condition)
-		     (cerror "ACCEPT" "~S~%  ~A~%occured while inside python-output-thread" condition condition))
-		   (end-of-file (condition)
-		     ;; User will get a debugger from the interaction thread, better to only have one
-		     ;; Messages will probably be garbled as we write from two threads, but better than nothing
-		     (notify-user
-			     "Python #~A: EOF on STDERR ~A received ~@[last message was ~A~]~%"
-			     (python-id python)
-			     condition (unless (emptyp (python-output-result python))
-					 (python-output-result python))))
-                   (stream-error (condition)
-                     (unless (member :abcl *features*)
-                       (cerror "ACCEPT" "~S~%  ~A~%occured while inside python-output-thread" condition condition)))))
+		          (handler-case
+			      (let ((char (read-char py-out)))
+			        (when char
+			          (if (python-in-with-python-output python)
+				      (progn
+				        (bt:with-lock-held (output-lock)
+				          (assert (< (length (python-output-result python)) 10000000))
+				          (vector-push-extend char (python-output-result python))))
+				      (progn
+                                        (vector-push-extend char *spurious-info*)
+				        (when (> (- (get-universal-time) last-notified-of-spurious-output) 1)
+				          (notify-user "Spurious output from python #~A:~A~%"
+                                                       (python-id python)
+                                                       (format nil "~A" *spurious-info*))
+                                          (setf (fill-pointer *spurious-info*) 0)
+				          (setf last-notified-of-spurious-output (get-universal-time)))))))
+                          (simple-error (condition)
+		                        (cerror "ACCEPT" "~S~%  ~A~%occured while inside python-output-thread" condition condition))
+		          (end-of-file (condition)
+		                       ;; User will get a debugger from the interaction thread, better to only have one
+		                       ;; Messages will probably be garbled as we write from two threads, but better than nothing
+		                       (notify-user
+			                "Python #~A: EOF on STDERR ~A received ~@[last message was ~A~]~%"
+			                (python-id python)
+			                condition (unless (emptyp (python-output-result python))
+					            (python-output-result python))))
+                          (stream-error (condition)
+                                        (unless (member :abcl *features*)
+                                          (cerror "ACCEPT" "~S~%  ~A~%occured while inside python-output-thread" condition condition))))))
 	       :name "stderr thread")))
       (assert (python-alive-p python))
       (setf (python-numpy-installed python) (numpy-installed-p python))

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -19,60 +19,57 @@ HANDLE slot is a unique key used to refer to a value in python."
         (progn
           (terpri s)
           (pprint-logical-block (s nil :per-line-prefix "  ")
-            (format s "~A" (pyeval "str(" o ")")))
+            ;; Doing this prevents infinite error loops if someone tries
+            ;; to print out an object that causes an error which contains
+            ;; the object which...
+            (let ((*print-python-object* nil))
+              (format s "~A" (pyeval "str(" o ")"))))
           (terpri s))
         (with-slots (type handle) o
           (format s ":HANDLE ~A :TYPE ~A" handle type)))))
 
-(defvar *freed-python-objects* nil
-  "A list of handles to be freed. This is used because garbage collection may occur in parallel with the main thread.")
+(defun free-python-object (id handle &optional (python *python*))
+  (push (cons id handle) (python-freed-python-objects python)))
 
-(defun free-python-object (python-id handle)
-  (push (list python-id handle) *freed-python-objects*))
-
-(defun delete-freed-python-objects ()
-  ;; Remove (python-id handle) pairs from the list and process
-  (loop for id-handle = (pop *freed-python-objects*)
+(defun delete-freed-python-objects (&optional (python *python*))
+  ;; Remove (python-id . handle) pairs from the list and process
+  (loop for id-handle = (pop (python-freed-python-objects python))
      while id-handle
-     do (let ((python-id (first id-handle))
-              (handle (second id-handle)))
-          (if (and
-               (python-alive-p) ; If not alive, pyexec will start python
-               (= *current-python-process-id* python-id))  ; Python might have restarted
-              ;; Call the internal function, to avoid infinite recursion or deadlock
+	do
+	   (destructuring-bind (id . handle)
+	       id-handle
+	     ;; Don't bother if python dead or we restarted it
+           (when (and (python-alive-p python) (= (python-id python) id))
               (raw-pyexec "
 try:
   del _py4cl_objects[" (%pythonize handle) "]
 except:
   pass")))))
 
-(defvar *numpy-pickle-index*)
-
-(defun delete-numpy-pickle-arrays ()
+(defun delete-numpy-pickle-arrays (&optional (python *python*))
   "Delete pickled arrays, to free space."
-  (iter (while (> *numpy-pickle-index* 0))
-    (decf *numpy-pickle-index*)
-    (for filename =
+  (loop
+    while (> (python-numpy-pickle-index python) 0)
+    do
+       (decf (python-numpy-pickle-index python))
+       (let ((filename 
          (concatenate 'string
                       (config-var 'numpy-pickle-location)
-                      ".to." (write-to-string *numpy-pickle-index*)))
-    (uiop:delete-file-if-exists filename)))
+			    "-" (write-to-string (python-id python))
+			    ".to." (write-to-string (python-numpy-pickle-index python)))))
+	 (uiop:delete-file-if-exists filename))))
 
-(defun make-python-object-finalize (&key (type "") handle)
+(defun make-python-object-finalize (&key (type "") handle (python *python*))
     "Make a PYTHON-OBJECT struct with a finalizer.
-This deletes the object from the dict store in python.
-
-Uses trivial-garbage (public domain)
-"
+ This deletes the object from the dict store in python."
     (tg:finalize
-     (make-python-object :type type
-                         :handle handle)
-     (let ((python-id *current-python-process-id*))
+     (make-python-object :type type :handle handle)
+     (let ((id (python-id python)))
        (lambda () ; This function is called when the python-object is garbage collected
          (ignore-errors
            ;; Put on a list to free later. Garbage collection may happen
            ;; in parallel with the main thread, which may be executing other commands.
-           (free-python-object python-id handle))))))
+          (free-python-object id handle python))))))
 
 (defun stream-read-string (stream)
   "Reads a string from a stream
@@ -80,16 +77,17 @@ Expects a line containing the number of chars following
 e.g. '5~%hello'
 Returns the string or nil on error
 "
-  (let ((nchars (parse-integer (read-line stream))))
-    (with-output-to-string (str)
-      (iter (for i from 1 to nchars)
-        (for char = (read-char stream))
-        (write-char char str)))))
+  (declare (optimize speed safety))
+  (let* ((nchars (parse-integer (read-line stream)))
+         (seq (make-array nchars :element-type 'character)))
+    (read-sequence seq stream)
+    seq))
 
 (defun stream-read-value (stream)
   "Get a value from a stream
 Currently works by reading a string then using read-from-string
 "
+  (declare (optimize speed safety))
   (let ((str (stream-read-string stream)))
     (multiple-value-bind (value count)
         (read-from-string str)

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -83,6 +83,14 @@ Returns the string or nil on error
     (read-sequence seq stream)
     seq))
 
+(defun read-value (string)
+  (multiple-value-bind (value count)
+      (read-from-string string)
+    ;; Check if all characters were used
+    (unless (eql count (length string))
+      (error (concatenate 'string "unread characters in reading string \"" string "\"")))
+    value))
+
 (defun stream-read-value (stream)
   "Get a value from a stream
 Currently works by reading a string then using read-from-string

--- a/src/reader.lisp
+++ b/src/reader.lisp
@@ -46,6 +46,11 @@ try:
 except:
   pass")))))
 
+(defun read-and-delete-numpy-file (filename)
+  (prog1
+      (numpy-file-format:load-array filename)
+    (uiop:delete-file-if-exists filename)))
+
 (defun delete-numpy-pickle-arrays (&optional (python *python*))
   "Delete pickled arrays, to free space."
   (loop

--- a/src/writer.lisp
+++ b/src/writer.lisp
@@ -6,14 +6,16 @@
 ;;;
 ;;; Object Handles
 
+;; This is not thread-safe
 (defvar *handle-counter* 0)
 
 (defvar *lisp-objects* (make-hash-table :test #'eql))
 
-(defun clear-lisp-objects ()
+(defun clear-lisp-objects (python)
   "Clear the *lisp-objects* object store, allowing them to be GC'd"
-  (setf *lisp-objects* (make-hash-table :test #'eql)
-        *handle-counter* 0))
+  (loop for handle = (pop (python-lisp-objects python))
+	while handle
+	do (remhash handle *lisp-objects*)))
 
 (defun free-handle (handle)
   "Remove an object with HANDLE from the hash table"

--- a/src/writer.lisp
+++ b/src/writer.lisp
@@ -100,10 +100,6 @@ which is interpreted correctly by python (3.7.2)."
                (write-to-string (imagpart obj))
                "j)"))
 
-(defvar *numpy-pickle-index* 0
-  "Used for transferring multiple numpy-pickled arrays in one pyeval/exec/etc")
-;; this is incremented by pythonize and reset to 0 at the beginning of
-;; every pyeval*/pycall from delete-numpy-pickle-arrays in reader.lisp
 (defmethod pythonize ((obj array))
   (when (and *warn-on-unavailable-feature-usage*
              (not (member :arrays *internal-features*))
@@ -137,8 +133,9 @@ Is numpy installed on python side?"
       (cond ((member :fast-large-array-transfer *internal-features*)
              (let ((filename (concatenate 'string
                                           (config-var 'numpy-pickle-location)
-                                          ".to." (write-to-string *numpy-pickle-index*))))
-               (incf *numpy-pickle-index*)
+					  "-" (write-to-string (python-id *python*))
+                                          ".to." (write-to-string (python-numpy-pickle-index *python*)))))
+               (incf (python-numpy-pickle-index *python*))
                (numpy-file-format:store-array obj filename)
                (return-from pythonize
                  (concatenate 'string "_py4cl_load_pickled_ndarray('"

--- a/src/writer.lisp
+++ b/src/writer.lisp
@@ -30,6 +30,7 @@
   "Store OBJECT and return a handle"
   (let ((handle (incf *handle-counter*)))
     (setf (gethash handle *lisp-objects*) object)
+    (sb-ext:atomic-push handle (python-lisp-objects *python*))
     handle))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -60,7 +61,9 @@ Default implementation creates a handle to an unknown Lisp object.")
                              "- _py4cl_numpy.float32('inf')")
                             (t
                              (concatenate 'string "_py4cl_numpy.float32("
-                                          (substitute #\e #\f (write-to-string obj)) ")"))))
+                                          (substitute #\e #\f
+                                                      (write-to-string obj))
+                                          ")"))))
         (double-float (cond ((float-features:float-nan-p obj)
                              "_py4cl_numpy.float64('nan')")
                             ((= obj float-features:double-float-positive-infinity)

--- a/src/writer.lisp
+++ b/src/writer.lisp
@@ -9,7 +9,7 @@
 ;; This is not thread-safe
 (defvar *handle-counter* 0)
 
-(defvar *lisp-objects* (make-hash-table :test #'eql))
+(defvar *lisp-objects* (make-hash-table :test #'eql :synchronized t))
 
 (defun clear-lisp-objects (python)
   "Clear the *lisp-objects* object store, allowing them to be GC'd"

--- a/src/writer.lisp
+++ b/src/writer.lisp
@@ -138,7 +138,7 @@ Is numpy installed on python side?"
                                           (config-var 'numpy-pickle-location)
 					  "-" (write-to-string (python-id *python*))
                                           ".to." (write-to-string (python-numpy-pickle-index *python*)))))
-               (incf (python-numpy-pickle-index *python*))
+               (sb-ext:atomic-incf (python-numpy-pickle-index *python*))
                (numpy-file-format:store-array obj filename)
                (return-from pythonize
                  (concatenate 'string "_py4cl_load_pickled_ndarray('"

--- a/src/writer.lisp
+++ b/src/writer.lisp
@@ -137,8 +137,8 @@ Is numpy installed on python side?"
              (let ((filename (concatenate 'string
                                           (config-var 'numpy-pickle-location)
 					  "-" (write-to-string (python-id *python*))
-                                          ".to." (write-to-string (python-numpy-pickle-index *python*)))))
-               (sb-ext:atomic-incf (python-numpy-pickle-index *python*))
+                                          ".to." (write-to-string (sb-ext:atomic-incf
+                                                                      (python-numpy-pickle-index *python*))))))
                (numpy-file-format:store-array obj filename)
                (return-from pythonize
                  (concatenate 'string "_py4cl_load_pickled_ndarray('"

--- a/src/writer.lisp
+++ b/src/writer.lisp
@@ -60,7 +60,7 @@ Default implementation creates a handle to an unknown Lisp object.")
                              "- _py4cl_numpy.float32('inf')")
                             (t
                              (concatenate 'string "_py4cl_numpy.float32("
-                                          (write-to-string obj) ")"))))
+                                          (substitute #\e #\f (write-to-string obj)) ")"))))
         (double-float (cond ((float-features:float-nan-p obj)
                              "_py4cl_numpy.float64('nan')")
                             ((= obj float-features:double-float-positive-infinity)


### PR DESCRIPTION
This is obviously a pretty big change, in particular the multiple python processes one.  It passes all the py4cl2-tests though!  

I'm not sure how the original code passed all the tests, though --- the with-python-output relied on timing alone which doesn't work perfectly... even after flushing stuff on both sides, there's still time for the data to not reach the lisp side before we exit... relying on a sleep call is not reliable.  So I added something a bit more complex but it works 100% of the time.

I haven't started using this heavily, though, so there's absolutely no rush to work through merging this or looking through the changes.  I'm just opening this PR so you know where I am.  In my cl-matplotlib repo, you can see it running an animated graph updating from some python code while also sending callbacks into lisp as you press buttons which then callback into python to update the graph (the PyQt python side is fragile as I haven't put any time into it yet, so if you close the main window python dies horribly some amount of the time).

Below picture the sine wave is being animated from python code, the button is calling back into lisp and updating the plot.

<img width="1136" height="1459" alt="image" src="https://github.com/user-attachments/assets/70a3286f-176d-4d35-98aa-34a983af4a53" />

